### PR TITLE
WriteStream close event

### DIFF
--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -121,8 +121,8 @@ GridWriteStream.prototype.end = function end (data) {
   var self = this;
   this.on('drain', function () {
     self._store.close(function (err, file) {
-      if (err) self._error(err);
-      self.emit('close', err, file);
+      if (err) return self._error(err);
+      self.emit('close', file);
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -180,8 +180,7 @@ describe('test', function(){
         progress = size;
       });
 
-      ws.on('close', function (err, file) {
-        assert(err === null);
+      ws.on('close', function (file) {
         assert(file.filename === 'closeEvent.png')
         assert(file.contentType === 'image/png')
         assert(progress > 0);


### PR DESCRIPTION
In a project I'm working on, we decided to use the gridfs-stream module to interact with the GridStore native mongodb driver.

Everything worked just fine, expect in one use case where we were using the Step lib to perform several asynchronous calls, the basic flow was:

Crop original image to create thumbnail
Save thumbnail on GridFs
Save thumbnail ID in our media obj(mongoose model)
Save original image on GridFs
Save original image ID in our media obj
Save media obj

The problem with this approach was that the close event for the WriteStream didn't return the object added to the GridFs db, so we had to make two extra calls to the GridFs db to get back their IDs to reference them in the media obj.

The proposed patch sends the file added to the GridFs db as an argument in the WriteStream close event, this way it will be possible to manipulate the properties of the newly created file in the GridFs db later in the code.
Also if any error happens the close event will get a reference to it.

I added a unit test to check the changes to this patch.
