### PR TITLE
Filename was not being set when tryParseObjectId succeeded in writestream.js.

### DIFF
--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -40,7 +40,6 @@ function GridWriteStream (grid, filename, options) {
   } else {
     this.id = new grid.mongo.BSONPure.ObjectID;
     if ('string' == typeof filename) {
-      console.log("filename is string");
       // filenames are not unique
       // http://mongodb.github.com/node-mongodb-native/api-generated/gridstore.html
       this.name = filename;


### PR DESCRIPTION
Hi!

Here's one quick modification to the writestream. The filename was not being set when tryParseObjectId succeeded. Was this by purpose or just a bug?
