### PR TITLE
Fixed error when using different collection name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@ Object.defineProperty(Grid.prototype, 'files', {
 
 Grid.prototype.collection = function (name) {
   name || (name = this.mongo.GridStore.DEFAULT_ROOT_COLLECTION);
-  return this._col = this.db.collection(name + ".files");
+  return this._col = this.db.collection(name);
 }
 
 /**

--- a/lib/readstream.js
+++ b/lib/readstream.js
@@ -50,6 +50,8 @@ function GridReadStream (grid, filename, options) {
     : options || {};
 
   this.mode = 'r';
+  
+  this.options.root = grid._col.collectionName;
 
   this._store = new grid.mongo.GridStore(grid.db, _id, this.name, this.mode, this.options)
 


### PR DESCRIPTION
Signed-off-by: DominicBoettger Dominic.Boettger@inspirationlabs.com

When creating a readstream with a different collection name it's needed to add the root. "files" and "chunks" then gets automatically added.

Tested for Readstream!
