### PR TITLE
gridfs-stream should be able to store 12 lettered file names

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,15 +31,18 @@ function Grid (db, mongo) {
 }
 
 /**
- * Creates a writable stream ior the given `filename`.
+ * Creates a writable stream for the given `filename`.
  *
- * @param {ObjectId|String} filename
+ * __NOTE__ It is advised to pass a filename using the option 'filename', since some filenames can not be distinguished
+ * from ObjectIds
+ *
+ * @param {ObjectId|String} objectId (optional)
  * @param {Object} [options]
  * @return Stream
  */
 
-Grid.prototype.createWriteStream = function (filename, options) {
-  return new GridWriteStream(this, filename, options);
+Grid.prototype.createWriteStream = function (objectId, options) {
+  return new GridWriteStream(this, objectId, options);
 }
 
 /**

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -30,7 +30,9 @@ function GridWriteStream (grid, filename, options) {
   this._opening = false;
 
   this._grid = grid;
-  this.name = '';
+  this.options = filename && 'Object' == filename.constructor.name
+      ? filename
+      : options || {};
 
   if (filename && filename.toHexString) {
     this.id = filename;
@@ -41,14 +43,11 @@ function GridWriteStream (grid, filename, options) {
     if ('string' == typeof filename) {
       // filenames are not unique
       // http://mongodb.github.com/node-mongodb-native/api-generated/gridstore.html
-      this.name = filename;
+      this.options.filename = filename;
     }
   }
 
-  this.options = filename && 'Object' == filename.constructor.name
-    ? filename
-    : options || {};
-
+  this.name = this.options.filename || '';
   this.options.limit || (this.options.limit = Infinity);
 
   this.mode = this.options.mode && /^w[+]?$/.test(this.options.mode)

--- a/test/index.js
+++ b/test/index.js
@@ -104,8 +104,8 @@ describe('test', function(){
       assert(ws.name == 'logo.png')
     })
     describe('options', function(){
-      it('should have one key', function(){
-        assert(Object.keys(ws.options).length === 1);
+      it('should have two keys', function(){
+        assert(Object.keys(ws.options).length === 2);
       });
       it('limit should be Infinity', function(){
         assert(ws.options.limit === Infinity)
@@ -189,7 +189,6 @@ describe('test', function(){
       var pipe = readStream.pipe(ws);
     });
 
-
     it('should pipe more data to an existing GridFS file', function(done){
       function pipe (id, cb) {
         if (!cb) cb = id, id = null;
@@ -211,6 +210,11 @@ describe('test', function(){
           });
         });
       })
+    });
+
+    it('should be able to store a 12-letter file name', function() {
+      var rs = g.createWriteStream({ filename: '12345678.png' });
+      assert.equal(rs.name,'12345678.png');
     });
   });
 


### PR DESCRIPTION
Issue #11
