### PR TITLE
Don't overwrite existing filename when rewriting a file by _id without a new filename

### DIFF
--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -39,20 +39,24 @@ function GridWriteStream (grid, options) {
     this.id = ( options._id.toHexString ? options._id :  grid.tryParseObjectId(options._id) );
   }
 
+  this.name = this.options.filename;  // This may be undefined, that's okay
+
   if (!this.id) {
     //_id not passed or unparsable? This is a new file!
     this.id = new grid.mongo.BSONPure.ObjectID;
+    this.name = this.name || '';  // A new file needs a name
   }
 
-  this.name = this.options.filename || '';
   this.options.limit || (this.options.limit = Infinity);
   this.mode = this.options.mode && /^w[+]?$/.test(this.options.mode)
     ? this.options.mode
     : 'w+';
 
   this._q = [];
-  // for a write stream, the 2nd parameter is treated 'specially' by the gridstore: an id as string === filename!!
-  this._store = new grid.mongo.GridStore(grid.db, this.id || this.name, this.name, this.mode, this.options);
+
+  // The value of this.name may be undefined. GridStore treats that as a missing param
+  // in the call signature, which is what we want.
+  this._store = new grid.mongo.GridStore(grid.db, this.id, this.name, this.mode, this.options);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "mocha": "*",
-    "mongodb": "1.4.0"
+    "mongodb": "1.4.3"
   },
   "optionalDependencies": {},
   "engines": {


### PR DESCRIPTION
Don't overwrite the filename with '' (empty string) when rewriting a file by _id without providing another filename.  Bug manifested in gridfs-stream after a related bug was fixed in node-mongodb-native 1.4.3 (see https://github.com/mongodb/node-mongodb-native/pull/1169).
