### PR TITLE
Support for arbitrary "_id" types

### DIFF
--- a/lib/readstream.js
+++ b/lib/readstream.js
@@ -35,8 +35,12 @@ function GridReadStream (grid, options) {
     options = { filename: options };
   }
   this.options = options || {};
-  if (options._id) {
-      this.id = ( options._id.toHexString ? options._id :  grid.tryParseObjectId(options._id) );
+  if(options._id) {
+    this.id = grid.tryParseObjectId(options._id);
+
+    if(!this.id) {
+      this.id = options._id;
+    }
   }
 
   this.name = this.options.filename || '';

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -35,8 +35,12 @@ function GridWriteStream (grid, options) {
     options = { filename: options };
   }
   this.options = options || {};
-  if (options._id) {
-    this.id = ( options._id.toHexString ? options._id :  grid.tryParseObjectId(options._id) );
+  if(options._id) {
+    this.id = grid.tryParseObjectId(options._id);
+
+    if(!this.id) {
+      this.id = options._id;
+    }
   }
 
   this.name = this.options.filename;  // This may be undefined, that's okay

--- a/test/index.js
+++ b/test/index.js
@@ -269,6 +269,18 @@ describe('test', function(){
       });
       var pipe = readStream.pipe(ws);
     });
+
+    it('should create files with an _id of arbitrary type', function(done){
+      var readStream = fs.createReadStream(imgReadPath, { bufferSize: 1024 });
+      var ws = g.createWriteStream({ _id: 'an_arbitrary_id', filename: 'file.img'});
+
+      ws.on('close', function (file) {
+        assert(file._id === 'an_arbitrary_id');
+        done();
+      });
+
+      var pipe = readStream.pipe(ws);
+    });
   });
 
   describe('createReadStream', function(){
@@ -482,6 +494,16 @@ describe('test', function(){
       });
 
       rs.pipe(writeStream);
+    });
+
+    it('should read files with an _id of arbitrary type', function(done){
+      var rs = g.createReadStream({ _id: 'an_arbitrary_id'});
+
+      rs.on('open', function () {
+        assert(rs.id === 'an_arbitrary_id');
+        done();
+      });
+
     });
 
     it('should allow checking for existence of files', function(done){


### PR DESCRIPTION
The "_id" of a file in the GridFS can be of any type (not just ObjectID), see:

  http://mongodb.github.io/node-mongodb-native/api-generated/gridstore.html

Our application uses custom "_id" types and  we noticed that gridfs-stream did not work as expected, tracked it down to a hard-coded support for ObjectIDs as the only supported type for "_id".

This simple pull request adds support for any type of object as the "_id", however to mantain backward compatibility strings of 12 or 24 characters are considered ObjectID identifiers and treated as such.

Added a couple of unit tests to test the new functionality.
