### PR TITLE
Exposing gridstore open callback arguments to the open event

### DIFF
--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -167,10 +167,10 @@ GridWriteStream.prototype._open = function _open () {
   this._opening = true;
 
   var self = this;
-  this._store.open(function (err) {
+  this._store.open(function (err, store) {
     if (err) return self._error(err);
     self._opened = true;
-    self.emit('open');
+    self.emit('open', store);
     self._flush();
   });
 }


### PR DESCRIPTION
Exposing the gridstore object to the open event.
