### PR TITLE
Let native stream implementation decide if stream can be paused

### DIFF
--- a/lib/readstream.js
+++ b/lib/readstream.js
@@ -177,9 +177,8 @@ GridReadStream.prototype._read = function _read () {
   });
 
   this.pause = function () {
-    // native doesn't always pause.
-    // bypass its pause() method to hack it
-    self.paused = stream.paused = true;
+    stream.pause();
+    self.paused = stream.paused;
   }
 
   this.resume = function () {


### PR DESCRIPTION
Bypassing the native stream's pause behaviour can cause it to emit an
'end' event before the last data chunk is emitted. Depending on the
stream consumer, this leads to incomplete files being read from GridFS.
For example, when the stream is piped to an HTTP response, the response
is terminated before the last chunk is sent.

The problem is described in more detail in issue #46 which also contains
a link to a script reproducing the problem. The problematic behaviour
occurs randomly, probably depending on the order the chunks are read
(or partially read) from MongoDB.
