### PR TITLE
Implement node v0.10 style streams

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -122,7 +122,7 @@ Grid.prototype.exist = function (options, callback) {
 
 Grid.prototype.tryParseObjectId = function tryParseObjectId (string) {
   try {
-    return new this.mongo.BSONPure.ObjectID(string);
+    return new this.mongo.ObjectID(string);
   } catch (_) {
     return false;
   }

--- a/lib/readstream.js
+++ b/lib/readstream.js
@@ -50,8 +50,8 @@ function GridReadStream (grid, options) {
   this.name = this.options.filename || '';
   this.mode = 'r';
 
-  // If chunk size specified use it for read chunk size otherwise default to 128k. chunkSize specified in gridfs-stream docs, chunk_size in mongodb api.
-  this._chunkSize = this.options.chunkSize || this.options.chunk_size || 1024 * 128;
+  // If chunk size specified use it for read chunk size otherwise default to 255k (GridStore default). chunkSize and chunk_size in mongodb api so check both.
+  this._chunkSize = this.options.chunkSize || this.options.chunk_size || 1024 * 255;
 
   this.range = this.options.range || { startPos: 0, endPos: undefined };
   if (typeof(this.range.startPos) === 'undefined') {
@@ -72,10 +72,12 @@ function GridReadStream (grid, options) {
   //Close the store once `end` received
   this.on('end', function() {
     self._end = true;
-	self._close()
+    self._close()
   });
 
-  this._open();
+  process.nextTick(function() {
+    self._open();
+  });
 }
 
 /**
@@ -101,30 +103,30 @@ GridReadStream.prototype._open = function _open () {
   this._store.open(function (err, gs) {
     if (err) return self._error(err);
 
-	// Find the length of the file by setting the head to the end of the file and requesting the position
-	self._store.seek(0, self._grid.mongo.GridStore.IO_SEEK_END, function(err) {
-		if (err) return self._error(err);
+    // Find the length of the file by setting the head to the end of the file and requesting the position
+    self._store.seek(0, self._grid.mongo.GridStore.IO_SEEK_END, function(err) {
+        if (err) return self._error(err);
 
-		// Request the position of the end of the file
-		self._store.tell(function(err, position) {
-		if (err) return self._error(err);
+        // Request the position of the end of the file
+        self._store.tell(function(err, position) {
+        if (err) return self._error(err);
 
-			// Calculate the correct end position either from EOF or end of range. Also handle incorrect range request.
-			if (!self.range.endPos || self.range.endPos > position-1) {self.range.endPos = position - 1};
+            // Calculate the correct end position either from EOF or end of range. Also handle incorrect range request.
+            if (!self.range.endPos || self.range.endPos > position-1) {self.range.endPos = position - 1};
 
-			// Set the read head to the beginning of the file or start possition if specified
-			self._store.seek(self.range.startPos, self._grid.mongo.GridStore.IO_SEEK_SET, function(err) {
-			  if (err) return self._error(err);
+            // Set the read head to the beginning of the file or start possition if specified
+            self._store.seek(self.range.startPos, self._grid.mongo.GridStore.IO_SEEK_SET, function(err) {
+              if (err) return self._error(err);
 
-			  // The store is now open
-			  self.emit('open');
-			  self._opened = true;
+              // The store is now open
+              self.emit('open');
+              self._opened = true;
 
-			  // If _read() was allready called then we need to start pushing data to the stream. Otherwise _read() will handle this once called from stream.
-			  if (self.needToPush) self._push();
-			});
-		});
-	});
+              // If _read() was allready called then we need to start pushing data to the stream. Otherwise _read() will handle this once called from stream.
+              if (self.needToPush) self._push();
+            });
+        });
+    });
   });
 }
 
@@ -164,33 +166,29 @@ GridReadStream.prototype._push = function _push () {
   // Check if EOF, if the full requested range has been pushed or if the stream must be destroyed. If so than push EOF-signalling `null` chunk
   if ( !this._store.eof() && (self._currentPos <= self.range.endPos) && !this._end) {
 
-	// Determine the chunk size for the read from GridStore
-	// Use default chunk size or user specified
-	var readChunkSize = self._chunkSize
-	// Override the chunk size if the chunk size is more than left until EOF/range
-	if (self.range.endPos-self._currentPos < self._chunkSize) {readChunkSize = self.range.endPos - self._currentPos + 1};
+    // Determine the chunk size for the read from GridStore
+    // Use default chunk size or user specified
+    var readChunkSize = self._chunkSize
+    // Override the chunk size if the chunk size is more than left until EOF/range
+    if (self.range.endPos-self._currentPos < self._chunkSize) {readChunkSize = self.range.endPos - self._currentPos + 1};
 
-	// Read the chunk from GridSore. Head moves automaticly after each read.
+    // Read the chunk from GridSore. Head moves automaticly after each read.
     self._store.read(readChunkSize,function(err, data) {
 
-	  // If error stop and close the store
-	  if (err) return self._error(err);
+      // If error stop and close the store
+      if (err) return self._error(err);
 
-	  // Advance the current position of the read head
+      // Advance the current position of the read head
       self._currentPos += data.length;
 
-	  // Push the data to the stream buffer until the readstream is saturated. `self.push(data)` will return false then.
-      if (!self._end && self.push(data)) {
-        process.nextTick(function() {
-          self._push();
-        });
-      }
+      // Push data
+      if (!self._end) self.push(data)
     })
 
 
   } else {
-	// Push EOF-signalling `null` chunk
-	this._end = true;
+    // Push EOF-signalling `null` chunk
+    this._end = true;
     self.push(null);
   }
 }

--- a/lib/readstream.js
+++ b/lib/readstream.js
@@ -51,7 +51,7 @@ function GridReadStream (grid, options) {
     this.range.startPos = 0;
   }
 
-  this._store = new grid.mongo.GridStore(grid.db, this.id || new grid.mongo.BSONPure.ObjectID, this.name, this.mode, this.options);
+  this._store = new grid.mongo.GridStore(grid.db, this.id || new grid.mongo.ObjectID(), this.name, this.mode, this.options);
   // Workaround for Gridstore issue https://github.com/mongodb/node-mongodb-native/pull/930
   if (!this.id) {
     //var REFERENCE_BY_FILENAME = 0,

--- a/lib/readstream.js
+++ b/lib/readstream.js
@@ -126,7 +126,7 @@ GridReadStream.prototype._pipe = function _pipe (gsReadStream) {
     //If end of requested range then end stream and close the store
     if (isGreatThanEndPos) {
       gsReadStream.end();
-      self.emit('end');
+      self.end();
       self._close();
     }
 
@@ -135,9 +135,9 @@ GridReadStream.prototype._pipe = function _pipe (gsReadStream) {
   });
 
   //If end of stream is reached emit `end` and close the store
-  gsReadStream.on('end', function (data) {
+  gsReadStream.on('end', function () {
     if (!isGreatThanEndPos) {
-        self.emit('end', data);
+        self.end();
         self._close();
     }
   });

--- a/lib/readstream.js
+++ b/lib/readstream.js
@@ -4,7 +4,7 @@
  */
 
 var util = require('util');
-var PassThrough  = require('stream').PassThrough;
+var Readable  = require('stream').Readable;
 
 /**
  * expose
@@ -24,9 +24,10 @@ function GridReadStream (grid, options) {
   if (!(this instanceof GridReadStream))
     return new GridReadStream(grid, options);
 
-  PassThrough.call(this);
+  Readable.call(this);
   this._opened = false;
   this._opening = false;
+  this._closed = false;
   this._end = false;
 
   this._grid = grid;
@@ -49,10 +50,15 @@ function GridReadStream (grid, options) {
   this.name = this.options.filename || '';
   this.mode = 'r';
 
+  // If chunk size specified use it for read chunk size otherwise default to 128k. chunkSize specified in gridfs-stream docs, chunk_size in mongodb api.
+  this._chunkSize = this.options.chunkSize || this.options.chunk_size || 1024 * 128;
+
   this.range = this.options.range || { startPos: 0, endPos: undefined };
   if (typeof(this.range.startPos) === 'undefined') {
     this.range.startPos = 0;
   }
+
+  this._currentPos = this.range.startPos;
 
   this._store = new grid.mongo.GridStore(grid.db, this.id || new grid.mongo.ObjectID(), this.name, this.mode, this.options);
   // Workaround for Gridstore issue https://github.com/mongodb/node-mongodb-native/pull/930
@@ -61,15 +67,23 @@ function GridReadStream (grid, options) {
     this._store.referenceBy = 0;
   }
 
+  var self = this;
+
+  //Close the store once `end` received
+  this.on('end', function() {
+    self._end = true;
+	self._close()
+  });
+
   this._open();
 }
 
 /**
- * Inherit from stream.PassThrough
+ * Inherit from stream.Readable
  * @ignore
  */
 
-util.inherits(GridReadStream, PassThrough);
+util.inherits(GridReadStream, Readable);
 
 /**
  * _open
@@ -82,83 +96,103 @@ GridReadStream.prototype._open = function _open () {
   this._opening = true;
 
   var self = this;
+
+  // Open the sore
   this._store.open(function (err, gs) {
     if (err) return self._error(err);
-    self._opened = true;
-    gs.seek(self.range.startPos, function(err) {
-      if (err) return self._error(err);
-      self.emit('open');
-      self._pipe(gs.stream());
-    });
+
+	// Find the length of the file by setting the head to the end of the file and requesting the position
+	self._store.seek(0, self._grid.mongo.GridStore.IO_SEEK_END, function(err) {
+		if (err) return self._error(err);
+
+		// Request the position of the end of the file
+		self._store.tell(function(err, position) {
+		if (err) return self._error(err);
+
+			// Calculate the correct end position either from EOF or end of range. Also handle incorrect range request.
+			if (!self.range.endPos || self.range.endPos > position-1) {self.range.endPos = position - 1};
+
+			// Set the read head to the beginning of the file or start possition if specified
+			self._store.seek(self.range.startPos, self._grid.mongo.GridStore.IO_SEEK_SET, function(err) {
+			  if (err) return self._error(err);
+
+			  // The store is now open
+			  self.emit('open');
+			  self._opened = true;
+
+			  // If _read() was allready called then we need to start pushing data to the stream. Otherwise _read() will handle this once called from stream.
+			  if (self.needToPush) self._push();
+			});
+		});
+	});
   });
 }
 
 /**
- * _pipe
+ * _read
  *
  * @api private
  */
 
-GridReadStream.prototype._pipe = function _pipe (gsReadStream) {
+// _read will be called when the stream wants to pull more data in
+// the advisory size argument is ignored in this case and user specified use or default to 128k.
+GridReadStream.prototype._read = function _read (size) {
   var self = this;
-  if (!this._opened) return self._error('Unable to pipe. Expected gridstore to be open');
 
-  // Init range request
-  var currentPos = self.range.startPos;
-  var isGreatThanEndPos = false;
+  // Set needToPush to true because the store may still be closed if data is immediatly piped. Once the store is open needToPush is checked and _push() called if neccassary.
+  self.needToPush = true;
 
-  // Pipe implementation
-  // Unable to just use gsReadStream.pipe(self) becuase you cant sepeficy end range in gridStore, only where to begin.
-  // No need to handle setEncoding as the PassThrough stream handels it.
-  gsReadStream.on('data', function (data) {
-    // Control the range of data sent
-    if (typeof(self.range.endPos) !== 'undefined' && currentPos + data.length > self.range.endPos + 1) {
-      isGreatThanEndPos = true;
-      data = data.slice(0, self.range.endPos - currentPos + 1);
-    }
+  // The store must be open
+  if (!this._opened) return;
 
-    // Write data and pause if stream gets saturated
-    var ready = self.write(data);
-    if (ready === false) {
-        gsReadStream.pause();
-        self.once('drain', this.resume.bind(this));
-    }
+  // Read data from GridStore and push to stream
+  self._push();
+}
 
-    // If end of requested range then end stream and close the store
-    if (isGreatThanEndPos) {
-      self._end = true;
-      gsReadStream.end();
-      self.end();
-      self._close();
-    }
+/**
+ * _push
+ *
+ * @api private
+ */
 
-    // Keep track of the data that is sent
-    currentPos += data.length;
-  });
+GridReadStream.prototype._push = function _push () {
+  var self = this;
 
-  // If end of gsReadStream is reached emit `end` and close the store
-  gsReadStream.on('end', function () {
-    if (!isGreatThanEndPos && !self._end) {
-        self._end = true;
-        self.end();
-        self._close();
-    }
-  });
+  // Do not continue if the store is closed
+  if (!this._opened) return self._error('Unable to push data. Expected gridstore to be open');
 
-  // Pass on error events and clsoe the store
-  gsReadStream.on('error', function(err) {
-    self._error(err);
-  });
+  // Check if EOF, if the full requested range has been pushed or if the stream must be destroyed. If so than push EOF-signalling `null` chunk
+  if ( !this._store.eof() && (self._currentPos <= self.range.endPos) && !this._end) {
 
-  // If stream was ended end gsReadStream and close the store
-  self.on('end', function() {
-    if (!self._end) {
-      self._end = true;
-      gsReadStream.end();
-      self._close();
-    }
-  });
+	// Determine the chunk size for the read from GridStore
+	// Use default chunk size or user specified
+	var readChunkSize = self._chunkSize
+	// Override the chunk size if the chunk size is more than left until EOF/range
+	if (self.range.endPos-self._currentPos < self._chunkSize) {readChunkSize = self.range.endPos - self._currentPos + 1};
 
+	// Read the chunk from GridSore. Head moves automaticly after each read.
+    self._store.read(readChunkSize,function(err, data) {
+
+	  // If error stop and close the store
+	  if (err) return self._error(err);
+
+	  // Advance the current position of the read head
+      self._currentPos += data.length;
+
+	  // Push the data to the stream buffer until the readstream is saturated. `self.push(data)` will return false then.
+      if (!self._end && self.push(data)) {
+        process.nextTick(function() {
+          self._push();
+        });
+      }
+    })
+
+
+  } else {
+	// Push EOF-signalling `null` chunk
+	this._end = true;
+    self.push(null);
+  }
 }
 
 /**
@@ -169,10 +203,17 @@ GridReadStream.prototype._pipe = function _pipe (gsReadStream) {
 
 GridReadStream.prototype._close = function _close () {
   var self = this;
+
+  // Emit close if store is not opend and _close() called
   if (!self._opened) return self.emit('close');
 
+  // Do not close store if allready closed
+  if (self._closed) return;
+
+  // Close the store and emit `close` event
   self._store.close(function (err) {
     if (err) return self._error(err);
+    self._closed = true;
     self.emit('close');
   });
 }
@@ -184,10 +225,13 @@ GridReadStream.prototype._close = function _close () {
  */
 
 GridReadStream.prototype._error = function _error (err) {
+  // Set end true so that no further reads from GridSotre are possible and close the store
+  this._end = true;
+
   // Emit the error event
   this.emit('error', err);
 
-  //Close the gridsore if an error is received.
+  // Close the gridsore if an error is received.
   this._close()
 }
 
@@ -198,6 +242,8 @@ GridReadStream.prototype._error = function _error (err) {
  */
 
 GridReadStream.prototype.destroy = function destroy () {
+  // Set end true so that no further reads from GridSotre are possible and close the store
+  this._end = true;
   this._close();
 }
 

--- a/lib/readstream.js
+++ b/lib/readstream.js
@@ -27,8 +27,9 @@ function GridReadStream (grid, options) {
   Readable.call(this);
   this._opened = false;
   this._opening = false;
-  this._closed = false;
+  this._closing = false;
   this._end = false;
+  this._needToPush = false;
 
   this._grid = grid;
 
@@ -122,8 +123,8 @@ GridReadStream.prototype._open = function _open () {
               self.emit('open');
               self._opened = true;
 
-              // If _read() was allready called then we need to start pushing data to the stream. Otherwise _read() will handle this once called from stream.
-              if (self.needToPush) self._push();
+              // If `_read()` was allready called then we need to start pushing data to the stream. Otherwise `_read()` will handle this once called from stream.
+              if (self._needToPush) self._push();
             });
         });
     });
@@ -136,13 +137,13 @@ GridReadStream.prototype._open = function _open () {
  * @api private
  */
 
-// _read will be called when the stream wants to pull more data in
-// the advisory size argument is ignored in this case and user specified use or default to 128k.
+// `_read()` will be called when the stream wants to pull more data in
+// The advisory `size` argument is ignored in this case and user specified use or default to 255kk.
 GridReadStream.prototype._read = function _read (size) {
   var self = this;
 
-  // Set needToPush to true because the store may still be closed if data is immediatly piped. Once the store is open needToPush is checked and _push() called if neccassary.
-  self.needToPush = true;
+  // Set `_needToPush` to true because the store may still be closed if data is immediatly piped. Once the store is open `_needToPush` is checked and _push() called if neccassary.
+  self._needToPush = true;
 
   // The store must be open
   if (!this._opened) return;
@@ -169,7 +170,7 @@ GridReadStream.prototype._push = function _push () {
     // Determine the chunk size for the read from GridStore
     // Use default chunk size or user specified
     var readChunkSize = self._chunkSize
-    // Override the chunk size if the chunk size is more than left until EOF/range
+    // Override the chunk size if the chunk size is more than the size that is left until EOF/range
     if (self.range.endPos-self._currentPos < self._chunkSize) {readChunkSize = self.range.endPos - self._currentPos + 1};
 
     // Read the chunk from GridSore. Head moves automaticly after each read.
@@ -201,17 +202,13 @@ GridReadStream.prototype._push = function _push () {
 
 GridReadStream.prototype._close = function _close () {
   var self = this;
-
-  // Emit close if store is not opend and _close() called
-  if (!self._opened) return self.emit('close');
-
-  // Do not close store if allready closed
-  if (self._closed) return;
+  if (!self._opened) return;
+  if (self._closing) return;
+  this._closing = true;
 
   // Close the store and emit `close` event
   self._store.close(function (err) {
     if (err) return self._error(err);
-    self._closed = true;
     self.emit('close');
   });
 }

--- a/lib/readstream.js
+++ b/lib/readstream.js
@@ -115,7 +115,7 @@ GridReadStream.prototype._open = function _open () {
             // Calculate the correct end position either from EOF or end of range. Also handle incorrect range request.
             if (!self.range.endPos || self.range.endPos > position-1) {self.range.endPos = position - 1};
 
-            // Set the read head to the beginning of the file or start possition if specified
+            // Set the read head to the beginning of the file or start position if specified
             self._store.seek(self.range.startPos, self._grid.mongo.GridStore.IO_SEEK_SET, function(err) {
               if (err) return self._error(err);
 
@@ -123,7 +123,7 @@ GridReadStream.prototype._open = function _open () {
               self.emit('open');
               self._opened = true;
 
-              // If `_read()` was allready called then we need to start pushing data to the stream. Otherwise `_read()` will handle this once called from stream.
+              // If `_read()` was already called then we need to start pushing data to the stream. Otherwise `_read()` will handle this once called from stream.
               if (self._needToPush) self._push();
             });
         });
@@ -142,7 +142,7 @@ GridReadStream.prototype._open = function _open () {
 GridReadStream.prototype._read = function _read (size) {
   var self = this;
 
-  // Set `_needToPush` to true because the store may still be closed if data is immediatly piped. Once the store is open `_needToPush` is checked and _push() called if neccassary.
+  // Set `_needToPush` to true because the store may still be closed if data is immediately piped. Once the store is open `_needToPush` is checked and _push() called if necessary.
   self._needToPush = true;
 
   // The store must be open
@@ -173,7 +173,7 @@ GridReadStream.prototype._push = function _push () {
     // Override the chunk size if the chunk size is more than the size that is left until EOF/range
     if (self.range.endPos-self._currentPos < self._chunkSize) {readChunkSize = self.range.endPos - self._currentPos + 1};
 
-    // Read the chunk from GridSore. Head moves automaticly after each read.
+    // Read the chunk from GridSore. Head moves automatically after each read.
     self._store.read(readChunkSize,function(err, data) {
 
       // If error stop and close the store

--- a/lib/readstream.js
+++ b/lib/readstream.js
@@ -3,8 +3,8 @@
  * Module dependencies
  */
 
-var Stream = require('stream').Stream;
-var fs = require('fs');
+var util = require('util');
+var PassThrough  = require('stream').PassThrough;
 
 /**
  * expose
@@ -24,9 +24,9 @@ function GridReadStream (grid, options) {
   if (!(this instanceof GridReadStream))
     return new GridReadStream(grid, options);
 
-  Stream.call(this);
-  this.paused = false;
-  this.readable = true;
+  PassThrough.call(this);
+  this._opened = false;
+  this._opening = false;
 
   this._grid = grid;
 
@@ -34,7 +34,9 @@ function GridReadStream (grid, options) {
   if (typeof options === 'string') {
     options = { filename: options };
   }
+
   this.options = options || {};
+
   if(options._id) {
     this.id = grid.tryParseObjectId(options._id);
 
@@ -58,46 +60,118 @@ function GridReadStream (grid, options) {
     this._store.referenceBy = 0;
   }
 
+  this._open();
+}
+
+/**
+ * Inherit from stream.PassThrough
+ * @ignore
+ */
+
+util.inherits(GridReadStream, PassThrough);
+
+/**
+ * _open
+ *
+ * @api private
+ */
+
+GridReadStream.prototype._open = function _open () {
+  if (this._opening) return;
+  this._opening = true;
+
   var self = this;
-  process.nextTick(function () {
-    self._open();
+  this._store.open(function (err, gs) {
+    if (err) return self._error(err);
+	self._opened = true;
+    gs.seek(self.range.startPos, function(err) {
+      if (err) return self._error(err);
+      self.emit('open');
+      self._pipe(gs.stream());
+    });
   });
 }
 
 /**
- * Inherit from Stream
- * @ignore
- */
-
-GridReadStream.prototype = { __proto__: Stream.prototype }
-
-// public api
-
-GridReadStream.prototype.readable;
-GridReadStream.prototype.paused;
-
-GridReadStream.prototype.setEncoding = fs.ReadStream.prototype.setEncoding;
-
-/**
- * pause
+ * _pipe
  *
- * @api public
+ * @api private
  */
 
-GridReadStream.prototype.pause = function pause () {
-  // Overridden when the GridStore opens.
-  this.paused = true;
+GridReadStream.prototype._pipe = function _pipe (gsReadStream) {
+  var self = this;
+  if (!this._opened) return self._error('Unable to pipe. Expected gridstore to be open');
+
+  //Init range request
+  var currentPos = self.range.startPos;
+  var isGreatThanEndPos = false;
+
+  //Pipe implementation
+  //Unable to just use gsReadStream.pipe(self) becuase you cant sepeficy end range in gridStore, only where to begin.
+  //No need to handle setEncoding as the PassThrough stream handels it.
+  gsReadStream.on('data', function (data) {
+	//Control the range of data sent
+    if (typeof(self.range.endPos) !== 'undefined' && currentPos + data.length > self.range.endPos + 1) {
+      isGreatThanEndPos = true;
+      data = data.slice(0, self.range.endPos - currentPos + 1);
+    }
+
+	//Write data and pause if stream gets saturated
+	var ready = self.write(data);
+	if (ready === false) {
+		this.pause();
+		self.once('drain', this.resume.bind(this));
+	}
+
+	//If end of requested range then end stream and close the store
+	if (isGreatThanEndPos) {
+      gsReadStream.end();
+      self.emit('end');
+      self._close();
+    }
+
+	//Keep track of the data that is sent
+	currentPos += data.length;
+  });
+
+  //If end of stream is reached emit `end` and close the store
+  gsReadStream.on('end', function (data) {
+	if (!isGreatThanEndPos) {
+		self.emit('end', data);
+		self._close();
+    }
+  });
+
 }
 
 /**
- * resume
+ * _close
  *
- * @api public
+ * @api private
  */
 
-GridReadStream.prototype.resume = function resume () {
-  // Overridden when the GridStore opens.
-  this.paused = false;
+GridReadStream.prototype._close = function _close () {
+  var self = this;
+  if (!self._opened) return self.emit('close');
+
+  self._store.close(function (err) {
+    if (err) return self._error(err);
+    self.emit('close');
+  });
+}
+
+/**
+ * _error
+ *
+ * @api private
+ */
+
+GridReadStream.prototype._error = function _error (err) {
+  // Emit the error event
+  this.emit('error', err);
+
+  //Close the gridsore if an error is received.
+  this._close()
 }
 
 /**
@@ -107,94 +181,6 @@ GridReadStream.prototype.resume = function resume () {
  */
 
 GridReadStream.prototype.destroy = function destroy () {
-  // Overridden when the GridStore opens.
-  this.readable = false;
-}
-
-// private api
-
-GridReadStream.prototype._open = function _open () {
-  var self = this;
-  this._store.open(function (err) {
-    if (err) return self._error(err);
-    if (!self.readable) return;
-    self._store.seek(self.range.startPos, function(err) {
-      if (err) return self._error(err);
-      self.emit('open');
-      self._read();
-    });
-  });
-}
-
-GridReadStream.prototype._read = function _read () {
-  //Don't check this.paused here -- paused or not, the stream needs to be prepared!
-  if (!this.readable || this.reading) {
-    return;
-  }
-
-  this.reading = true;
-
-  var self = this;
-  var stream = this._stream = this._store.stream();
-  stream.paused = this.paused;
-
-  var currentPos = self.range.startPos;
-  var isGreatThanEndPos = false;
-
-  stream.on('data', function (data) {
-    if (typeof(self.range.endPos) !== 'undefined' && currentPos + data.length > self.range.endPos + 1) {
-      isGreatThanEndPos = true;
-      data = data.slice(0, self.range.endPos - currentPos + 1);
-    }
-
-    if (self._decoder) {
-      var str = self._decoder.write(data);
-      if (str.length) self.emit('data', str);
-    } else {
-      self.emit('data', data);
-    }
-
-    if (isGreatThanEndPos) {
-      self.emit('end');
-      self.destroy();
-    }
-
-    currentPos += data.length;
-  });
-
-  stream.on('end', function (data) {
-    if (!isGreatThanEndPos) {
-      self.emit('end', data);
-    }
-  });
-
-  stream.on('error', function (data) {
-    self._error(data);
-  });
-
-  stream.on('close', function (data) {
-    self.emit('close', data);
-  });
-
-  this.pause = function () {
-    stream.pause();
-    self.paused = stream.paused;
-  }
-
-  this.resume = function () {
-    self.paused = false;
-    stream.resume();
-    self.readable = stream.readable;
-  }
-
-  this.destroy = function () {
-    self.readable = false;
-    stream.destroy();
-  }
-}
-
-GridReadStream.prototype._error = function _error (err) {
-  this.readable = false;
-  this.emit('error', err);
+  this._close();
 }
 

--- a/lib/readstream.js
+++ b/lib/readstream.js
@@ -83,7 +83,7 @@ GridReadStream.prototype._open = function _open () {
   var self = this;
   this._store.open(function (err, gs) {
     if (err) return self._error(err);
-	self._opened = true;
+    self._opened = true;
     gs.seek(self.range.startPos, function(err) {
       if (err) return self._error(err);
       self.emit('open');
@@ -110,35 +110,35 @@ GridReadStream.prototype._pipe = function _pipe (gsReadStream) {
   //Unable to just use gsReadStream.pipe(self) becuase you cant sepeficy end range in gridStore, only where to begin.
   //No need to handle setEncoding as the PassThrough stream handels it.
   gsReadStream.on('data', function (data) {
-	//Control the range of data sent
+    //Control the range of data sent
     if (typeof(self.range.endPos) !== 'undefined' && currentPos + data.length > self.range.endPos + 1) {
       isGreatThanEndPos = true;
       data = data.slice(0, self.range.endPos - currentPos + 1);
     }
 
-	//Write data and pause if stream gets saturated
-	var ready = self.write(data);
-	if (ready === false) {
-		this.pause();
-		self.once('drain', this.resume.bind(this));
-	}
+    //Write data and pause if stream gets saturated
+    var ready = self.write(data);
+    if (ready === false) {
+        this.pause();
+        self.once('drain', this.resume.bind(this));
+    }
 
-	//If end of requested range then end stream and close the store
-	if (isGreatThanEndPos) {
+    //If end of requested range then end stream and close the store
+    if (isGreatThanEndPos) {
       gsReadStream.end();
       self.emit('end');
       self._close();
     }
 
-	//Keep track of the data that is sent
-	currentPos += data.length;
+    //Keep track of the data that is sent
+    currentPos += data.length;
   });
 
   //If end of stream is reached emit `end` and close the store
   gsReadStream.on('end', function (data) {
-	if (!isGreatThanEndPos) {
-		self.emit('end', data);
-		self._close();
+    if (!isGreatThanEndPos) {
+        self.emit('end', data);
+        self._close();
     }
   });
 

--- a/lib/readstream.js
+++ b/lib/readstream.js
@@ -27,6 +27,7 @@ function GridReadStream (grid, options) {
   PassThrough.call(this);
   this._opened = false;
   this._opening = false;
+  this._end = false;
 
   this._grid = grid;
 
@@ -56,7 +57,7 @@ function GridReadStream (grid, options) {
   this._store = new grid.mongo.GridStore(grid.db, this.id || new grid.mongo.ObjectID(), this.name, this.mode, this.options);
   // Workaround for Gridstore issue https://github.com/mongodb/node-mongodb-native/pull/930
   if (!this.id) {
-    //var REFERENCE_BY_FILENAME = 0,
+    // var REFERENCE_BY_FILENAME = 0,
     this._store.referenceBy = 0;
   }
 
@@ -102,43 +103,59 @@ GridReadStream.prototype._pipe = function _pipe (gsReadStream) {
   var self = this;
   if (!this._opened) return self._error('Unable to pipe. Expected gridstore to be open');
 
-  //Init range request
+  // Init range request
   var currentPos = self.range.startPos;
   var isGreatThanEndPos = false;
 
-  //Pipe implementation
-  //Unable to just use gsReadStream.pipe(self) becuase you cant sepeficy end range in gridStore, only where to begin.
-  //No need to handle setEncoding as the PassThrough stream handels it.
+  // Pipe implementation
+  // Unable to just use gsReadStream.pipe(self) becuase you cant sepeficy end range in gridStore, only where to begin.
+  // No need to handle setEncoding as the PassThrough stream handels it.
   gsReadStream.on('data', function (data) {
-    //Control the range of data sent
+    // Control the range of data sent
     if (typeof(self.range.endPos) !== 'undefined' && currentPos + data.length > self.range.endPos + 1) {
       isGreatThanEndPos = true;
       data = data.slice(0, self.range.endPos - currentPos + 1);
     }
 
-    //Write data and pause if stream gets saturated
+    // Write data and pause if stream gets saturated
     var ready = self.write(data);
     if (ready === false) {
         gsReadStream.pause();
         self.once('drain', this.resume.bind(this));
     }
 
-    //If end of requested range then end stream and close the store
+    // If end of requested range then end stream and close the store
     if (isGreatThanEndPos) {
+      self._end = true;
       gsReadStream.end();
       self.end();
       self._close();
     }
 
-    //Keep track of the data that is sent
+    // Keep track of the data that is sent
     currentPos += data.length;
   });
 
-  //If end of stream is reached emit `end` and close the store
+  // If end of gsReadStream is reached emit `end` and close the store
   gsReadStream.on('end', function () {
-    if (!isGreatThanEndPos) {
+    if (!isGreatThanEndPos && !self._end) {
+        self._end = true;
         self.end();
         self._close();
+    }
+  });
+
+  // Pass on error events and clsoe the store
+  gsReadStream.on('error', function(err) {
+    self._error(err);
+  });
+
+  // If stream was ended end gsReadStream and close the store
+  self.on('end', function() {
+    if (!self._end) {
+      self._end = true;
+      gsReadStream.end();
+      self._close();
     }
   });
 

--- a/lib/readstream.js
+++ b/lib/readstream.js
@@ -119,7 +119,7 @@ GridReadStream.prototype._pipe = function _pipe (gsReadStream) {
     //Write data and pause if stream gets saturated
     var ready = self.write(data);
     if (ready === false) {
-        this.pause();
+        gsReadStream.pause();
         self.once('drain', this.resume.bind(this));
     }
 

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -55,7 +55,7 @@ function GridWriteStream (grid, options) {
     this.name = this.name || '';  // A new file needs a name
   }
 
-  this.mode = 'w'; //Mongodb v2 driver have disabled w+ because of possible data coruption. So only alow `w` for now.
+  this.mode = 'w'; //Mongodb v2 driver have disabled w+ because of possible data corruption. So only allow `w` for now.
 
   this._q = [];
 
@@ -104,7 +104,7 @@ GridWriteStream.prototype._open = function _open () {
     // If data was sent before store is open start writing to the store
     if (self._writePending) self._write();
 
-    // If `finished` allready received and no data left in queue close the store - this is mostly for an empty or very small files
+    // If `finished` already received and no data left in queue close the store - this is mostly for an empty or very small files
     if (self._finish && !self._writePending && self._q.length === 0) self._close();
   });
 }
@@ -121,7 +121,7 @@ GridWriteStream.prototype._write = function (chunk, encoding, done) {
   // If destroy is called no data will be written
   if (!this._writable) return;
 
-  // Used so that we know that there is data peninding for a write before the store is open and not to close the store to soon.
+  // Used so that we know that there is data pending for a write before the store is open and not to close the store too soon.
   this._writePending = true;
 
   // Queue data until we open. This queue only grow until the store is open then done() is only called after each successful GridStore write. This queue will only grow until the store opens and then it should remain at a maximum of 1. New data only sent after the previous one was written and `done()` called.

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -47,14 +47,14 @@ function GridWriteStream (grid, options) {
 
   if (!this.id) {
     //_id not passed or unparsable? This is a new file!
-    this.id = new grid.mongo.BSONPure.ObjectID;
+    this.id = new grid.mongo.ObjectID();
     this.name = this.name || '';  // A new file needs a name
   }
 
   this.options.limit || (this.options.limit = Infinity);
   this.mode = this.options.mode && /^w[+]?$/.test(this.options.mode)
     ? this.options.mode
-    : 'w+';
+    : 'w';
 
   this._q = [];
 

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -112,6 +112,8 @@ GridWriteStream.prototype._close = function _close () {
 GridWriteStream.prototype._pipe = function _pipe (gsWriteStream) {
   var self = this;
   if (!self._opened) return self._error('Unable to pipe.  Expected gridstore to be open');
+
+  // Close gridstore on end of stream
   gsWriteStream.on('end', function() {
       self._close();
   });

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -65,7 +65,7 @@ function GridWriteStream (grid, options) {
 
   var self = this;
 
-  // Close store if all data is written to the store when finished received. If data left in queue it will be finished and close after the GridStore write by checkin `_finish=true`
+  // Close store if all data was written to the store when `finished` received. If data left in queue dont close yet - first finish the queue and then close the store. The write function checks if there are data left in the queue and if `_finish=true`
   this.on('finish', function() {
     self._finish = true;
     if (self._opened && !self._writePending && self._q.length === 0) {
@@ -104,7 +104,7 @@ GridWriteStream.prototype._open = function _open () {
     // If data was sent before store is open start writing to the store
     if (self._writePending) self._write();
 
-    // If finished allready received and no data in queue close the store - this is mostly for an empty file
+    // If `finished` allready received and no data left in queue close the store - this is mostly for an empty or very small files
     if (self._finish && !self._writePending && self._q.length === 0) self._close();
   });
 }
@@ -116,15 +116,15 @@ GridWriteStream.prototype._open = function _open () {
  */
 
 GridWriteStream.prototype._write = function (chunk, encoding, done) {
-  // This function is called from the writestream and internally to write chunks received before the store is open.
+  // This function is called from the writestream and also internal to write chunks received before the store is open.
 
-  // If destroy is called now data will be written
+  // If destroy is called no data will be written
   if (!this._writable) return;
 
   // Used so that we know that there is data peninding for a write before the store is open and not to close the store to soon.
   this._writePending = true;
 
-  // queue data until we open. This queue only grow until the store is open then done() is only called after each successful GridStore write.
+  // Queue data until we open. This queue only grow until the store is open then done() is only called after each successful GridStore write. This queue will only grow until the store opens and then it should remain at a maximum of 1. New data only sent after the previous one was written and `done()` called.
   if (!this._opened) {
     if (chunk) {
       // Push the chunk in the queue
@@ -139,7 +139,7 @@ GridWriteStream.prototype._write = function (chunk, encoding, done) {
 
   var self = this;
 
-  // Write the first chunk in the queue to the GridStore
+  // Write the first chunk in the queue to the GridStore. The write head automatically moves along with each write.
   this._store.write(this._q.shift(), function (err, store) {
     if (err) return self._error(err);
     self._writePending = false;
@@ -147,10 +147,10 @@ GridWriteStream.prototype._write = function (chunk, encoding, done) {
     // Emit the write head position
     self.emit('progress', store.position);
 
-    // If there are more data in the queue from data received before the store was open write them
+    // If there is more data in the queue from data received before the store was open write them
     if (self._q.length > 0) self._write();
 
-    // If finished received from the writestream then the data is done and only data left in queue must be writtem
+    // If `finished` received from the writestream then the data is done and only data left in queue must be written
     if (self._q.length === 0 && (self._finish || self._destroying)) {
       self._close();
     }
@@ -199,7 +199,7 @@ GridWriteStream.prototype._error = function _error (err) {
  */
 
 GridWriteStream.prototype.destroy = function destroy () {
-  // close and do not emit any more events. queued data is not sent.
+  // Close and do not emit any more events. queued data is not sent.
   if (!this._writable) return;
   this._writable = false;
   this._q.length = 0;
@@ -213,8 +213,8 @@ GridWriteStream.prototype.destroy = function destroy () {
  */
 
 GridWriteStream.prototype.destroySoon = function destroySoon () {
-  // as soon as write queue is drained, destroy.
-  // may call destroy immediately if no data is queued.
+  // As soon as write queue is drained, destroy.
+  // May call destroy immediately if no data is queued.
   if (!this._q.length) {
     return this.destroy();
   }

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -4,7 +4,7 @@
  */
 
 var util = require('util');
-var PassThrough  = require('stream').PassThrough ;
+var PassThrough  = require('stream').PassThrough;
 
 /**
  * expose
@@ -51,7 +51,7 @@ function GridWriteStream (grid, options) {
     this.name = this.name || '';  // A new file needs a name
   }
 
-  this.mode = 'w';
+  this.mode = 'w'; //Mongodb v2 driver have disabled w+ because of write possible data coruption. So only alow `w` for now.
 
   // The value of this.name may be undefined. GridStore treats that as a missing param
   // in the call signature, which is what we want.
@@ -82,7 +82,7 @@ GridWriteStream.prototype._open = function _open () {
   var self = this;
   this._store.open(function (err, gs) {
     if (err) return self._error(err);
-	self._opened = true;
+    self._opened = true;
     self.emit('open');
     self._pipe(gs.stream());
   });
@@ -122,7 +122,7 @@ GridWriteStream.prototype._pipe = function _pipe (gsWriteStream) {
   // Emit progress
   var size = 0;
   self.on('data', function(data) {
-	  size += data.length;
+      size += data.length;
       self.emit('progress',size);
   });
 

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -3,7 +3,8 @@
  * Module dependencies
  */
 
-var Stream = require('stream').Stream;
+var util = require('util');
+var PassThrough  = require('stream').PassThrough ;
 
 /**
  * expose
@@ -23,8 +24,7 @@ function GridWriteStream (grid, options) {
   if (!(this instanceof GridWriteStream))
     return new GridWriteStream(grid, options);
 
-  Stream.call(this);
-  this.writable = true;
+  PassThrough .call(this);
   this._opened = false;
   this._opening = false;
 
@@ -51,112 +51,21 @@ function GridWriteStream (grid, options) {
     this.name = this.name || '';  // A new file needs a name
   }
 
-  this.options.limit || (this.options.limit = Infinity);
-  this.mode = this.options.mode && /^w[+]?$/.test(this.options.mode)
-    ? this.options.mode
-    : 'w';
-
-  this._q = [];
+  this.mode = 'w';
 
   // The value of this.name may be undefined. GridStore treats that as a missing param
   // in the call signature, which is what we want.
   this._store = new grid.mongo.GridStore(grid.db, this.id, this.name, this.mode, this.options);
+
   this._open();
 }
 
 /**
- * Inherit from Stream
+ * Inherit from stream.PassThrough
  * @ignore
  */
 
-GridWriteStream.prototype = { __proto__: Stream.prototype }
-
-// public api
-
-// TODO docs
-GridWriteStream.prototype.writable;
-GridWriteStream.prototype.name;
-GridWriteStream.prototype.id;
-GridWriteStream.prototype.options;
-GridWriteStream.prototype.mode;
-
-/**
- * write
- *
- * @param {Buffer|String} data
- */
-
-GridWriteStream.prototype.write = function write (data) {
-  if (!this.writable) {
-    throw new Error('GridWriteStream is not writable');
-  }
-
-  // queue data until we open.
-  if (!this._opened) {
-    this._q.push(data);
-    return false;
-  }
-
-  this._q.push(data);
-  if (this._q.length > this.options.limit) {
-    this._flush();
-    return false;
-  }
-
-  this._flush();
-  return true;
-};
-
-/**
- * end
- *
- * @param {Buffer|String} data
- */
-
-GridWriteStream.prototype.end = function end (data) {
-  // allow queued data to write before closing
-  if (!this.writable) return;
-  this.writable = false;
-
-  if (data) {
-    this._q.push(data);
-  }
-
-  var self = this;
-  this.on('drain', function () {
-    self._store.close(function (err, file) {
-      if (err) return self._error(err);
-      self.emit('close', file);
-    });
-  });
-
-  this._flush();
-};
-
-/**
- * destroy
- */
-
-GridWriteStream.prototype.destroy = function destroy () {
-  // close and do not emit any more events. queued data is not sent.
-  if (!this.writable) return;
-  this.writable = false;
-  this._q.length = 0;
-  this.emit('close');
-};
-
-/**
- * destroySoon
- */
-
-GridWriteStream.prototype.destroySoon = function destroySoon () {
-  // as soon as write queue is drained, destroy.
-  // may call destroy immediately if no data is queued.
-  if (!this._q.length) {
-    return this.destroy();
-  }
-  this._destroying = true;
-};
+util.inherits(GridWriteStream, PassThrough);
 
 // private api
 
@@ -171,12 +80,52 @@ GridWriteStream.prototype._open = function _open () {
   this._opening = true;
 
   var self = this;
-  this._store.open(function (err) {
+  this._store.open(function (err, gs) {
     if (err) return self._error(err);
-    self._opened = true;
+	self._opened = true;
     self.emit('open');
-    self._flush();
+    self._pipe(gs.stream());
   });
+}
+
+/**
+ * _close
+ *
+ * @api private
+ */
+
+GridWriteStream.prototype._close = function _close () {
+  var self = this;
+  if (!this._opened) return self.emit('close');
+  self._store.close(function (err, file) {
+    if (err) return self._error(err);
+    self.emit('close', file);
+  });
+}
+
+/**
+ * _pipe
+ *
+ * @api private
+ */
+
+GridWriteStream.prototype._pipe = function _pipe (gsWriteStream) {
+  var self = this;
+  if (!self._opened) return self._error('Unable to pipe.  Expected gridstore to be open');
+  gsWriteStream.on('end', function() {
+      self._close();
+  });
+
+  // Pipe readstream to gridstore
+  self.pipe(gsWriteStream);
+
+  // Emit progress
+  var size = 0;
+  self.on('data', function(data) {
+	  size += data.length;
+      self.emit('progress',size);
+  });
+
 }
 
 /**
@@ -186,37 +135,26 @@ GridWriteStream.prototype._open = function _open () {
  */
 
 GridWriteStream.prototype._error = function _error (err) {
-  this.destroy();
   this.emit('error', err);
+  this._close();
 }
 
 /**
- * _flush
+ * destroy
  *
- * @api private
+ * @api public
  */
 
-GridWriteStream.prototype._flush = function _flush (_force) {
-  if (!this._opened) return;
-  if (!_force && this._flushing) return;
-  this._flushing = true;
-
-  // write the entire q to gridfs
-  if (!this._q.length) {
-    this._flushing = false;
-    this.emit('drain');
-
-    if (this._destroying) {
-      this.destroy();
-    }
-    return;
-  }
-
-  var self = this;
-  this._store.write(this._q.shift(), function (err, store) {
-    if (err) return self._error(err);
-    self.emit('progress', store.position);
-    self._flush(true);
-  });
+GridWriteStream.prototype.destroy = function destroy () {
+  this._close();
 }
 
+/**
+ * destroySoon
+ *
+ * @api public
+ */
+
+GridWriteStream.prototype.destroySoon = function destroySoon () {
+  this._close();
+};

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -4,7 +4,7 @@
  */
 
 var util = require('util');
-var PassThrough  = require('stream').PassThrough;
+var Writable  = require('stream').Writable;
 
 /**
  * expose
@@ -24,9 +24,13 @@ function GridWriteStream (grid, options) {
   if (!(this instanceof GridWriteStream))
     return new GridWriteStream(grid, options);
 
-  PassThrough .call(this);
+  Writable .call(this);
   this._opened = false;
   this._opening = false;
+  this._finish = false;
+  this._writePending = false;
+  this._writable = true;
+  this._closing = false;
 
   this._grid = grid;
 
@@ -51,21 +55,33 @@ function GridWriteStream (grid, options) {
     this.name = this.name || '';  // A new file needs a name
   }
 
-  this.mode = 'w'; //Mongodb v2 driver have disabled w+ because of write possible data coruption. So only alow `w` for now.
+  this.mode = 'w'; //Mongodb v2 driver have disabled w+ because of possible data coruption. So only alow `w` for now.
+
+  this._q = [];
 
   // The value of this.name may be undefined. GridStore treats that as a missing param
   // in the call signature, which is what we want.
   this._store = new grid.mongo.GridStore(grid.db, this.id, this.name, this.mode, this.options);
 
-  this._open();
+  var self = this;
+
+  // Close store if all data is written to the store when finished received. If data left in queue it will be finished and close after the GridStore write by checkin `_finish=true`
+  this.on('finish', function() {
+    self._finish = true;
+    if (self._opened && !self._writePending && self._q.length === 0) {
+      self._close();
+    }
+  });
+
+  self._open();
 }
 
 /**
- * Inherit from stream.PassThrough
+ * Inherit from stream.Writable
  * @ignore
  */
 
-util.inherits(GridWriteStream, PassThrough);
+util.inherits(GridWriteStream, Writable);
 
 // private api
 
@@ -84,8 +100,67 @@ GridWriteStream.prototype._open = function _open () {
     if (err) return self._error(err);
     self._opened = true;
     self.emit('open');
-    self._pipe(gs.stream());
+
+    // If data was sent before store is open start writing to the store
+    if (self._writePending) self._write();
+
+    // If finished allready received and no data in queue close the store - this is mostly for an empty file
+    if (self._finish && !self._writePending && self._q.length === 0) self._close();
   });
+}
+
+/**
+ * _write
+ *
+ * @api private
+ */
+
+GridWriteStream.prototype._write = function (chunk, encoding, done) {
+  // This function is called from the writestream and internally to write chunks received before the store is open.
+
+  // If destroy is called now data will be written
+  if (!this._writable) return;
+
+  // Used so that we know that there is data peninding for a write before the store is open and not to close the store to soon.
+  this._writePending = true;
+
+  // queue data until we open. This queue only grow until the store is open then done() is only called after each successful GridStore write.
+  if (!this._opened) {
+    if (chunk) {
+      // Push the chunk in the queue
+      if (!this._destroying) this._q.push(chunk);
+      // Return done() so that the writestream will send another chunk for our queue
+      return done();
+    }
+  }
+
+  // If chunk then push to queue
+  if (chunk && !this._destroying) this._q.push(chunk);
+
+  var self = this;
+
+  // Write the first chunk in the queue to the GridStore
+  this._store.write(this._q.shift(), function (err, store) {
+    if (err) return self._error(err);
+    self._writePending = false;
+
+    // Emit the write head position
+    self.emit('progress', store.position);
+
+    // If there are more data in the queue from data received before the store was open write them
+    if (self._q.length > 0) self._write();
+
+    // If finished received from the writestream then the data is done and only data left in queue must be writtem
+    if (self._q.length === 0 && (self._finish || self._destroying)) {
+      self._close();
+    }
+
+    // We are ready to receive a new chunk from the writestream - call done().
+    if (chunk) {
+        done();
+    }
+    });
+
 }
 
 /**
@@ -96,38 +171,14 @@ GridWriteStream.prototype._open = function _open () {
 
 GridWriteStream.prototype._close = function _close () {
   var self = this;
-  if (!this._opened) return self.emit('close');
+  if (!this._opened) return;
+  if (this._closing) return;
+  this._closing = true;
+
   self._store.close(function (err, file) {
     if (err) return self._error(err);
     self.emit('close', file);
   });
-}
-
-/**
- * _pipe
- *
- * @api private
- */
-
-GridWriteStream.prototype._pipe = function _pipe (gsWriteStream) {
-  var self = this;
-  if (!self._opened) return self._error('Unable to pipe.  Expected gridstore to be open');
-
-  // Close gridstore on end of stream
-  gsWriteStream.on('end', function() {
-      self._close();
-  });
-
-  // Pipe readstream to gridstore
-  self.pipe(gsWriteStream);
-
-  // Emit progress
-  var size = 0;
-  self.on('data', function(data) {
-      size += data.length;
-      self.emit('progress',size);
-  });
-
 }
 
 /**
@@ -148,6 +199,10 @@ GridWriteStream.prototype._error = function _error (err) {
  */
 
 GridWriteStream.prototype.destroy = function destroy () {
+  // close and do not emit any more events. queued data is not sent.
+  if (!this._writable) return;
+  this._writable = false;
+  this._q.length = 0;
   this._close();
 }
 
@@ -158,5 +213,10 @@ GridWriteStream.prototype.destroy = function destroy () {
  */
 
 GridWriteStream.prototype.destroySoon = function destroySoon () {
-  this._close();
+  // as soon as write queue is drained, destroy.
+  // may call destroy immediately if no data is queued.
+  if (!this._q.length) {
+    return this.destroy();
+  }
+  this._destroying = true;
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "mocha": "*",
-    "mongodb": "1.4.3",
+    "mongodb": "2.0.14",
     "checksum": "~0.1.1"
   },
   "optionalDependencies": {},

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "mocha": "*",
-    "mongodb": "2.0.14",
+    "mongodb": "2.0.15",
     "checksum": "~0.1.1"
   },
   "optionalDependencies": {},

--- a/test/index.js
+++ b/test/index.js
@@ -117,7 +117,7 @@ describe('test', function(){
       assert(ws.name == 'logo.png')
     })
     describe('options', function(){
-	  //Limit removed as it is not used anymore
+      //Limit removed as it is not used anymore
       it('should have one key', function(){
         assert(Object.keys(ws.options).length === 1);
       });
@@ -567,7 +567,7 @@ describe('test', function(){
 
       rs.on('data', function (data) {
         rs.destroy();
-		done();
+        done();
       });
     });
 
@@ -607,37 +607,37 @@ describe('test', function(){
       });
     });
 
-	it('should be able to set the encoding of a readstream', function (done) {
+    it('should be able to set the encoding of a readstream', function (done) {
       var rs = g.createReadStream({ filename: 'logo.png' });
       rs.setEncoding('utf8');
 
       rs.on('data', function (data) {
-		assert.equal(typeof data, 'string');
-		rs.end();
+        assert.equal(typeof data, 'string');
+        rs.end();
         done();
       });
     });
 
-	it('should be able to pause/resume after a chunk is sent to be able to throttle the stream', function (done) {
-	  var rs = g.createReadStream({ filename: '1mbBlob' });
-	  var numChuksSent = 0
+    it('should be able to pause/resume after a chunk is sent to be able to throttle the stream', function (done) {
+      var rs = g.createReadStream({ filename: '1mbBlob' });
+      var numChuksSent = 0
 
       // Pause stream after one chunk has been sent
       rs.on('data', function (data) {
-		numChuksSent += 1;
-		rs.pause();
+        numChuksSent += 1;
+        rs.pause();
       });
 
       // Only one chunk should have been sent because it was paused after that. 1mbBlob contains 5 with default gridstream chunk size
-	  setTimeout(function () {
-		assert.equal( numChuksSent, 1 );
-		rs.resume();
+      setTimeout(function () {
+        assert.equal( numChuksSent, 1 );
+        rs.resume();
       }, 500);
 
-	  // Now there should be 2
-	  setTimeout(function () {
-		assert.equal( numChuksSent, 2 );
-		done()
+      // Now there should be 2
+      setTimeout(function () {
+        assert.equal( numChuksSent, 2 );
+        done()
       }, 1000);
 
     });

--- a/test/index.js
+++ b/test/index.js
@@ -613,7 +613,7 @@ describe('test', function(){
 
       rs.on('data', function (data) {
         assert.equal(typeof data, 'string');
-        rs.end();
+        rs.destroy();
         done();
       });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -111,7 +111,7 @@ describe('test', function(){
       assert(ws.id)
     })
     it('id should be an ObjectId', function(){
-      assert(ws.id instanceof mongo.BSONPure.ObjectID);
+      assert(ws.id instanceof mongo.ObjectID);
     });
     it('should have a name', function(){
       assert(ws.name == 'logo.png')
@@ -124,8 +124,8 @@ describe('test', function(){
         assert(ws.options.limit === Infinity)
       });
     })
-    it('mode should default to w+', function(){
-      assert(ws.mode == 'w+');
+    it('mode should default to w', function(){
+      assert(ws.mode == 'w');
     })
     it('should have an empty q', function(){
       assert(Array.isArray(ws._q));
@@ -203,30 +203,30 @@ describe('test', function(){
       var pipe = readStream.pipe(ws);
     });
 
-    it('should pipe more data to an existing GridFS file', function(done){
-      function pipe (id, cb) {
-        if (!cb) cb = id, id = null;
-        var readStream = fs.createReadStream(txtReadPath);
-        var ws = g.createWriteStream({
-          _id: id,
-          mode: 'w+' });
-        ws.on('close', function () {
-          cb(ws.id);
-        });
-        readStream.pipe(ws);
-      }
+    // it('should pipe more data to an existing GridFS file', function(done){
+    //   function pipe (id, cb) {
+    //     if (!cb) cb = id, id = null;
+    //     var readStream = fs.createReadStream(txtReadPath);
+    //     var ws = g.createWriteStream({
+    //       _id: id,
+    //       mode: 'w+' });
+    //     ws.on('close', function () {
+    //       cb(ws.id);
+    //     });
+    //     readStream.pipe(ws);
+    //   }
 
-      pipe(function (id) {
-        pipe(id, function (id) {
-          // read the file out. it should consist of two copies of original
-          mongo.GridStore.read(db, id, function (err, txt) {
-            if (err) return done(err);
-            assert.equal(txt.length, fs.readFileSync(txtReadPath).length*2);
-            done();
-          });
-        });
-      })
-    });
+    //   pipe(function (id) {
+    //     pipe(id, function (id) {
+    //       // read the file out. it should consist of two copies of original
+    //       mongo.GridStore.read(db, id, function (err, txt) {
+    //         if (err) return done(err);
+    //         assert.equal(txt.length, fs.readFileSync(txtReadPath).length*2);
+    //         done();
+    //       });
+    //     });
+    //   })
+    // });
 
     it('should be able to store a 12-letter file name', function() {
       var ws = g.createWriteStream({ filename: '12345678.png' });
@@ -330,7 +330,9 @@ describe('test', function(){
     })
     describe('options', function(){
       it('should have no defaults', function(){
-        assert(Object.keys(g.createReadStream({}).options).length === 0);
+        // NOTE: filename is required to avoid a throw here, because you can't create a valid
+        // read stream for a non-existing file. 
+        assert(Object.keys(g.createReadStream({filename: 'logo.png'}).options).length === 1);
       });
     })
     it('mode should default to r', function(){
@@ -420,7 +422,7 @@ describe('test', function(){
         _id: id
       });
       var writeStream = fs.createWriteStream(file);
-      assert(rs.id instanceof mongo.BSONPure.ObjectID);
+      assert(rs.id instanceof mongo.ObjectID);
       assert(rs.id == String(id))
 
       var opened = false;
@@ -469,7 +471,7 @@ describe('test', function(){
         }
       });
       var writeStream = fs.createWriteStream(file);
-      assert(rs.id instanceof mongo.BSONPure.ObjectID);
+      assert(rs.id instanceof mongo.ObjectID);
       assert(rs.id == String(id))
 
       var opened = false;


### PR DESCRIPTION
This PR follows from the discussion in https://github.com/aheckmann/gridfs-stream/pull/47

This will only work for the new mongo v2+ driver as is (indicate in readme?) but can be made backwards compatible to work with the old driver as well. 