### PR TITLE
Add findOne function and fix Grid.collection not reflecting name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,7 @@ function Grid (db, mongo) {
   // in old versions of the driver
   this.db = db;
   this.mongo = mongo;
+  this.curCol = this.mongo.GridStore ? this.mongo.GridStore.DEFAULT_ROOT_COLLECTION : 'fs';
 }
 
 /**
@@ -72,8 +73,8 @@ Object.defineProperty(Grid.prototype, 'files', {
  */
 
 Grid.prototype.collection = function (name) {
-  name || (name = this.mongo.GridStore.DEFAULT_ROOT_COLLECTION);
-  return this._col = this.db.collection(name + ".files");
+  this.curCol = name || this.curCol || this.mongo.GridStore.DEFAULT_ROOT_COLLECTION;
+  return this._col = this.db.collection(this.curCol + ".files");
 }
 
 /**
@@ -132,7 +133,7 @@ Grid.prototype.findOne = function (options, callback) {
   if (find._id) {
     find._id = this.tryParseObjectId(find._id) || find._id;
   }
-  var collection = options.root ? this.mongo.Collection(this.db, options.root+'.files', null, null) : this.files;
+  var collection = options.root  && options.root != this.curCol ? this.mongo.Collection(this.db, options.root+'.files', null, null) : this.files;
   if (!collection) {
     return callback(new Error('No collection specified'));
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -113,6 +113,37 @@ Grid.prototype.exist = function (options, callback) {
 }
 
 /**
+ * Find file by passing any options, at least an _id or filename
+ *
+ * @param {Object} options
+ * @param {Function} callback
+ */
+
+Grid.prototype.findOne = function (options, callback) {
+  if ('function' != typeof callback) {
+    throw new Error('findOne requires a callback function');
+  }
+  var find = {};
+  for (var n in options) {
+    if (n != 'root') {
+      find[n] = options[n];
+    }
+  }
+  if (find._id) {
+    find._id = this.tryParseObjectId(find._id) || find._id;
+  }
+  var collection = options.root ? this.mongo.Collection(this.db, options.root+'.files', null, null) : this.files;
+  if (!collection) {
+    return callback(new Error('No collection specified'));
+  }
+  collection.find(find, function(err, cursor) {
+    if (err) { return callback(err); }
+    if (!cursor) { return callback(new Error('Collection not found')); }
+    cursor.nextObject(callback);
+  });
+}
+
+/**
  * Attemps to parse `string` into an ObjectId
  *
  * @param {GridReadStream} self

--- a/lib/readstream.js
+++ b/lib/readstream.js
@@ -61,7 +61,11 @@ function GridReadStream (grid, options) {
 
   this._currentPos = this.range.startPos;
 
-  this._store = new grid.mongo.GridStore(grid.db, this.id || new grid.mongo.ObjectID(), this.name, this.mode, this.options);
+  var options = {};
+  for (var i in this.options) { options[i] = this.options[i]; }
+  options.root || (options.root = this._grid.curCol);
+
+  this._store = new grid.mongo.GridStore(grid.db, this.id || new grid.mongo.ObjectID(), this.name, this.mode, options);
   // Workaround for Gridstore issue https://github.com/mongodb/node-mongodb-native/pull/930
   if (!this.id) {
     // var REFERENCE_BY_FILENAME = 0,
@@ -241,4 +245,3 @@ GridReadStream.prototype.destroy = function destroy () {
   this._end = true;
   this._close();
 }
-

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -59,9 +59,13 @@ function GridWriteStream (grid, options) {
 
   this._q = [];
 
+  var options = {};
+  for (var i in this.options) { options[i] = this.options[i]; }
+  options.root || (options.root = this._grid.curCol);
+
   // The value of this.name may be undefined. GridStore treats that as a missing param
   // in the call signature, which is what we want.
-  this._store = new grid.mongo.GridStore(grid.db, this.id, this.name, this.mode, this.options);
+  this._store = new grid.mongo.GridStore(grid.db, this.id, this.name, this.mode, options);
 
   var self = this;
 

--- a/test/index.js
+++ b/test/index.js
@@ -547,6 +547,14 @@ describe('test', function(){
       });
     });
 
+    it('should get a specific file', function(done){
+      g.findOne({ _id: id }, function(err, result) {
+        if (err) return done(err);
+        assert.ok(result);
+        done();
+      });
+    })
+
     it('should allow removing files', function(done){
       g.remove({ _id: id }, function (err) {
         if (err) return done(err);


### PR DESCRIPTION
This is an implementation of the feature proposed here https://github.com/aheckmann/gridfs-stream/issues/62 and a fix for https://github.com/aheckmann/gridfs-stream/issues/59

Prototype: findOne(options, callback)

findOne can be used like mongodb's findOne:
```js
var gfs = Grid(db);

gfs.findOne({ _id: '54dd3fd6f9a55f1c1b25664d' }, function(err, res) {
  // res contains file or null if it did not match any file in the current collection
});
```

Optionally, it's possible to set options.root to specify which collection will the findOne execute on.
