### PR TITLE
Patch stream2 writable v2

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@ Easily stream files to and from MongoDB [GridFS](http://www.mongodb.org/display/
 
 ## Please note
 
-gridfs-stream v1.x uses node v0.10 style streams (mongodb v2.x driver). If for some reason you need node v0.8 style streams, please switch to the [gridfs-stream 0.x branch](https://github.com/aheckmann/gridfs-stream/tree/0.x)
+gridfs-stream v1.x uses [Stream2 API from nodejs v0.10](http://nodejs.org/docs/v0.10.36/api/stream.html) (and the mongodb v2.x driver). It provides more robust and easier to use streams. If for some reason you need nodejs v0.8 streams, please switch to the [gridfs-stream 0.x branch](https://github.com/aheckmann/gridfs-stream/tree/0.x)
 
 ## Description
 

--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@ Easily stream files to and from MongoDB [GridFS](http://www.mongodb.org/display/
 
 gridfs-stream v1.x uses node v0.10 style streams (mongodb v2.x driver). If for some reason you need node v0.8 style streams, please switch to the [gridfs-stream 0.x branch](https://github.com/aheckmann/gridfs-stream/tree/0.x)
 
-## Description 
+## Description
 
 ```js
 var mongo = require('mongodb');
@@ -94,7 +94,7 @@ Options may contain zero or more of the following options, for more information 
 
     //any other options from the GridStore may be passed too, e.g.:
 
-    chunkSize: 1024, 
+    chunkSize: 1024,
     content_type: 'plain/text', // For content_type to work properly, set "mode"-option to "w" too!
     root: 'my_collection',
     metadata: {

--- a/Readme.md
+++ b/Readme.md
@@ -120,6 +120,14 @@ writestream.on('close', function (file) {
 });
 ```
 
+### Methods
+
+The `writeStream` has additional methods:
+
+`destroy([err])`:
+Destroy the `writeStream` as soon as possible: stop writing incoming data, close the _store. An `error` event will be emitted, as well as a `close` event.
+It's up to you to cleanup the GridStore if it's not desired to keep half written files in GridFS (the `close` event returns a GridStore `file` which can be used to delete the file, or mark it failed).
+
 ## createReadStream
 
 To stream data out of GridFS we call `createReadStream` passing any options, at least an `_id` or `filename`.

--- a/Readme.md
+++ b/Readme.md
@@ -103,7 +103,15 @@ Options may contain zero or more of the following options, for more information 
 }
 ```
 
-The created File object is passed in the writeStreams `close` event.
+### Events
+
+The `writeStream` is a fully compliant [Stream2 Writable Stream](http://nodejs.org/docs/v0.10.36/api/stream.html#stream_class_stream_writable), it emits all the associated events (`drain`, `finish`, `pipe`, `unpipe`, `error`), as well as additional special events (`open`, `close`).
+
+`finish` is emitted after the file has been completely written to GridFS.
+
+`open` is emitted after the GridStore is successfully opened.
+
+`close` is emitted after the GridStore is successfully closed, which means the file is fully written to GridFS, and the file object is passed as the first argument.
 
 ```js
 writestream.on('close', function (file) {

--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@ Easily stream files to and from MongoDB [GridFS](http://www.mongodb.org/display/
 
 ## Please note
 
-gridfs-stream v1.x uses node v0.10 style streams. If for some reason you need node v0.8 style streams, please switch to the [gridfs-stream 0.x branch](https://github.com/aheckmann/gridfs-stream/tree/0.x)
+gridfs-stream v1.x uses node v0.10 style streams (mongodb v2.x driver). If for some reason you need node v0.8 style streams, please switch to the [gridfs-stream 0.x branch](https://github.com/aheckmann/gridfs-stream/tree/0.x)
 
 ## Description 
 
@@ -90,7 +90,7 @@ Options may contain zero or more of the following options, for more information 
 {
     _id: '50e03d29edfdc00d34000001', // a MongoDb ObjectId
     filename: 'my_file.txt', // a filename
-    mode: 'w', // default value: w+, possible options: w, w+ or r, see [GridStore](http://mongodb.github.com/node-mongodb-native/api-generated/gridstore.html)
+    mode: 'w', // default value: w
 
     //any other options from the GridStore may be passed too, e.g.:
 

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -116,21 +116,22 @@ GridWriteStream.prototype._open = function _open () {
  */
 
 GridWriteStream.prototype._write = function (chunk, encoding, done) {
-  // This function is called from the writestream and also internal to write chunks received before the store is open.
-
+  // This function is called from the writestream and also internal to write a chunk received before the store is open.
+  
+  // Store done until the gridstore is opened and only call when the chunk was successfully written.
+  if (chunk) this._done = done;
   // If destroy is called no data will be written
   if (!this._writable) return;
 
   // Used so that we know that there is data pending for a write before the store is open and not to close the store too soon.
   this._writePending = true;
 
-  // Queue data until we open. This queue only grow until the store is open then done() is only called after each successful GridStore write. This queue will only grow until the store opens and then it should remain at a maximum of 1. New data only sent after the previous one was written and `done()` called.
+  // There is data to write but the store is still closed. Queue the chunk until the store is opened then write it and call done(). The queue length will not grow because done() will only be called once the chunk is written.
   if (!this._opened) {
     if (chunk) {
       // Push the chunk in the queue
       if (!this._destroying) this._q.push(chunk);
-      // Return done() so that the writestream will send another chunk for our queue
-      return done();
+      return;
     }
   }
 
@@ -156,9 +157,7 @@ GridWriteStream.prototype._write = function (chunk, encoding, done) {
     }
 
     // We are ready to receive a new chunk from the writestream - call done().
-    if (chunk) {
-        done();
-    }
+	self._done();
     });
 
 }

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -61,6 +61,8 @@ function GridWriteStream (grid, options) {
   // in the call signature, which is what we want.
   this._store = new grid.mongo.GridStore(grid.db, this.id, this.name, this.mode, this.options);
 
+  this._delayedFlush = null;
+
   var self = this;
 
   self._open();
@@ -93,17 +95,18 @@ GridWriteStream.prototype._open = function () {
     self._opened = true;
     self.emit('open');
 
+    // If _flush was called during _store opening, then it was delayed until now, so do the flush now (it's necessarily an empty GridFS file, no _write could have been called and have finished)
+    if (self._delayedFlush) {
+      var flushed = self._delayedFlush;
+      self._delayedFlush = null;
+      self._flushInternal(flushed);
+    }
+
     // If data was sent before store is open start writing to the store
     if (self._delayedWrite) {
       var delayedWrite = self._delayedWrite;
       self._delayedWrite = null;
       return self._writeInternal(delayedWrite.chunk, delayedWrite.encoding, delayedWrite.done);
-    }
-
-    // If empty file
-    if (self._needToFlush  && !this._writePending) {
-      self._needToFlush();
-      self._close();
     }
   });
 }
@@ -122,20 +125,12 @@ GridWriteStream.prototype._writeInternal = function (chunk, encoding, done) {
   // Write the chunk to the GridStore. The write head automatically moves along with each write.
   this._store.write(chunk, function (err, store) {
     if (err) return self._error(err);
-    self._writePending = false;
 
     // Emit the write head position
     self.emit('progress', store.position);
 
     // We are ready to receive a new chunk from the writestream - call done().
     done();
-
-    // If we received an indication to flush - call _needToFlush and close the store.
-    if (self._needToFlush) {
-      self._needToFlush();
-      self._close();
-    }
-
   });
 }
 
@@ -146,9 +141,6 @@ GridWriteStream.prototype._writeInternal = function (chunk, encoding, done) {
  */
 
 GridWriteStream.prototype._write = function (chunk, encoding, done) {
-  // Used to know if its OK to close the store after an indication to flush is received.
-  this._writePending = true;
-
   // The store is not open but data is ready to be written so delay the write until the store is opened.
   if (!this._opened) {
     this._delayedWrite = {chunk: chunk, encoding: encoding, done: done};
@@ -160,20 +152,33 @@ GridWriteStream.prototype._write = function (chunk, encoding, done) {
 }
 
 /**
+ * _flushInternal
+ *
+ * @api private
+ */
+
+GridWriteStream.prototype._flushInternal = function (flushed) {
+  flushed();
+  this._close();
+}
+
+/**
  * _flush
  *
  * @api private
  */
 
 GridWriteStream.prototype._flush = function (flushed) {
-  // If no write is pending then complete the flush
-  if (!this._writePending && this._opened) {
-    flushed();
-    return this._close();
+  // _flush is called when all _write() have finished (even if no _write() was called (empty GridFS file))
+
+  if (this._opening) {
+    // if we are still opening the store, then delay the flush until it is open.
+    this._delayedFlush = flushed;
+    return;
   }
 
-  // If write outstanding defer the callback until it completes. Save the flushed callback and call it in the write method or after store opens if its an empty file.
-  this._needToFlush = flushed;
+  // otherwise, do the flush now
+  this._flushInternal(flushed);
 }
 
 /**

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -223,8 +223,8 @@ GridWriteStream.prototype._error = function _error (err) {
  * @api public
  */
 
-GridWriteStream.prototype.destroy = function destroy () {
-  // Stop receiving more data to write and close the store
-  this._writable = false;
-  this._close();
+GridWriteStream.prototype.destroy = function destroy (err) {
+  // Abort the write stream, even if write not completed
+  if (err === undefined) { err = new Error('destroyed'); }
+  this._error(err);
 }

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -95,7 +95,7 @@ GridWriteStream.prototype._open = function _open () {
     if (self._delayedWrite) return self._writeInternal(self._delayedWrite.chunk, self._delayedWrite.encoding, self._delayedWrite.done);
 
     // If empty file
-    if (self._needToFlush) {
+    if (self._needToFlush  && !this._writePending) {
       self._needToFlush();
       self._close();
     }
@@ -125,7 +125,7 @@ GridWriteStream.prototype._writeInternal = function (chunk, encoding, done) {
     done();
 
     // If we received an indication to flush - call _needToFlush and close the store.
-    if (self._needToFlush && !this._writePending) {
+    if (self._needToFlush) {
       self._needToFlush();
       self._close();
     }

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -4,7 +4,10 @@
  */
 
 var util = require('util');
-var Writable  = require('stream').Writable;
+//var Writable  = require('stream').Writable;
+
+// This is a workaround to implement a _flush method for Writable (like for Transform) to indicate that all data has been flushed to the underlying system. See https://www.npmjs.com/package/flushwritable and https://github.com/joyent/node/issues/7348
+var FlushWritable = require('flushwritable');
 
 /**
  * expose
@@ -24,14 +27,11 @@ function GridWriteStream (grid, options) {
   if (!(this instanceof GridWriteStream))
     return new GridWriteStream(grid, options);
 
-  Writable .call(this);
+  FlushWritable.call(this);
   this._opened = false;
   this._opening = false;
-  this._finish = false;
-  this._writePending = false;
   this._writable = true;
   this._closing = false;
-
   this._grid = grid;
 
   // a bit backwards compatible
@@ -57,31 +57,21 @@ function GridWriteStream (grid, options) {
 
   this.mode = 'w'; //Mongodb v2 driver have disabled w+ because of possible data corruption. So only allow `w` for now.
 
-  this._q = [];
-
   // The value of this.name may be undefined. GridStore treats that as a missing param
   // in the call signature, which is what we want.
   this._store = new grid.mongo.GridStore(grid.db, this.id, this.name, this.mode, this.options);
 
   var self = this;
 
-  // Close store if all data was written to the store when `finished` received. If data left in queue dont close yet - first finish the queue and then close the store. The write function checks if there are data left in the queue and if `_finish=true`
-  this.on('finish', function() {
-    self._finish = true;
-    if (self._opened && !self._writePending && self._q.length === 0) {
-      self._close();
-    }
-  });
-
   self._open();
 }
 
 /**
- * Inherit from stream.Writable
+ * Inherit from stream.Writable (FlushWritable for workaround to defer finish until all data flushed)
  * @ignore
  */
 
-util.inherits(GridWriteStream, Writable);
+util.inherits(GridWriteStream, FlushWritable);
 
 // private api
 
@@ -102,10 +92,44 @@ GridWriteStream.prototype._open = function _open () {
     self.emit('open');
 
     // If data was sent before store is open start writing to the store
-    if (self._writePending) self._write();
+    if (self._delayedWrite) return self._writeInternal(self._delayedWrite.chunk, self._delayedWrite.encoding, self._delayedWrite.done);
 
-    // If `finished` already received and no data left in queue close the store - this is mostly for an empty or very small files
-    if (self._finish && !self._writePending && self._q.length === 0) self._close();
+    // If empty file
+    if (self._needToFlush) {
+      self._needToFlush();
+      self._close();
+    }
+  });
+}
+
+/**
+ * _writeInternal
+ *
+ * @api private
+ */
+
+GridWriteStream.prototype._writeInternal = function (chunk, encoding, done) {
+  // If destroy or error no more data will be written.
+  if (!this._writable) return;
+
+  var self = this;
+  // Write the chunk to the GridStore. The write head automatically moves along with each write.
+  this._store.write(chunk, function (err, store) {
+    if (err) return self._error(err);
+    self._writePending = false;
+
+    // Emit the write head position
+    self.emit('progress', store.position);
+
+    // We are ready to receive a new chunk from the writestream - call done().
+    done();
+
+    // If we received an indication to flush - call _needToFlush and close the store.
+    if (self._needToFlush) {
+      self._needToFlush();
+      self._close();
+    }
+
   });
 }
 
@@ -116,50 +140,34 @@ GridWriteStream.prototype._open = function _open () {
  */
 
 GridWriteStream.prototype._write = function (chunk, encoding, done) {
-  // This function is called from the writestream and also internal to write a chunk received before the store is open.
-  
-  // Store done until the gridstore is opened and only call when the chunk was successfully written.
-  if (chunk) this._done = done;
-  // If destroy is called no data will be written
-  if (!this._writable) return;
-
-  // Used so that we know that there is data pending for a write before the store is open and not to close the store too soon.
+  // Used to know if its OK to close the store after an indication to flush is received.
   this._writePending = true;
 
-  // There is data to write but the store is still closed. Queue the chunk until the store is opened then write it and call done(). The queue length will not grow because done() will only be called once the chunk is written.
+  // The store is not open but data is ready to be written so delay the write until the store is opened.
   if (!this._opened) {
-    if (chunk) {
-      // Push the chunk in the queue
-      if (!this._destroying) this._q.push(chunk);
-      return;
-    }
+    this._delayedWrite = {chunk: chunk, encoding: encoding, done: done};
+    return
   }
 
-  // If chunk then push to queue
-  if (chunk && !this._destroying) this._q.push(chunk);
+  // The store is open so pass all arguments to _writeInternal to be written to the gridstore
+  this._writeInternal(chunk, encoding, done);
+}
 
-  var self = this;
+/**
+ * _flush
+ *
+ * @api private
+ */
 
-  // Write the first chunk in the queue to the GridStore. The write head automatically moves along with each write.
-  this._store.write(this._q.shift(), function (err, store) {
-    if (err) return self._error(err);
-    self._writePending = false;
+GridWriteStream.prototype._flush = function (flushed) {
+  // If all data has been flushed to the gridstore call flushed and close the store.
+  if (!this._writePending && this._opened) {
+    flushed();
+    return this._close();
+  }
 
-    // Emit the write head position
-    self.emit('progress', store.position);
-
-    // If there is more data in the queue from data received before the store was open write them
-    if (self._q.length > 0) self._write();
-
-    // If `finished` received from the writestream then the data is done and only data left in queue must be written
-    if (self._q.length === 0 && (self._finish || self._destroying)) {
-      self._close();
-    }
-
-    // We are ready to receive a new chunk from the writestream - call done().
-    self._done();
-    });
-
+  // If write outstanding defer the callback until it completes. Save the flushed callback and call it in the write method or after store opens if its an empty file.
+  this._needToFlush = flushed;
 }
 
 /**
@@ -169,12 +177,12 @@ GridWriteStream.prototype._write = function (chunk, encoding, done) {
  */
 
 GridWriteStream.prototype._close = function _close () {
-  var self = this;
   if (!this._opened) return;
   if (this._closing) return;
   this._closing = true;
 
-  self._store.close(function (err, file) {
+  var self = this;
+  this._store.close(function (err, file) {
     if (err) return self._error(err);
     self.emit('close', file);
   });
@@ -187,9 +195,13 @@ GridWriteStream.prototype._close = function _close () {
  */
 
 GridWriteStream.prototype._error = function _error (err) {
+  // Stop receiving more data to write, emit `error` and close the store
+  this._writable = false;
   this.emit('error', err);
   this._close();
 }
+
+// public api
 
 /**
  * destroy
@@ -198,24 +210,7 @@ GridWriteStream.prototype._error = function _error (err) {
  */
 
 GridWriteStream.prototype.destroy = function destroy () {
-  // Close and do not emit any more events. queued data is not sent.
-  if (!this._writable) return;
+  // Stop receiving more data to write and close the store
   this._writable = false;
-  this._q.length = 0;
   this._close();
 }
-
-/**
- * destroySoon
- *
- * @api public
- */
-
-GridWriteStream.prototype.destroySoon = function destroySoon () {
-  // As soon as write queue is drained, destroy.
-  // May call destroy immediately if no data is queued.
-  if (!this._q.length) {
-    return this.destroy();
-  }
-  this._destroying = true;
-};

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -229,6 +229,8 @@ GridWriteStream.prototype.destroy = function destroy (err) {
   if (this._destroyed) return;
   this._destroyed = true;
 
-  if (err === undefined) { err = new Error('destroyed'); }
-  this._error(err);
+  var self = this;
+  process.nextTick(function() {
+    self._error(err);
+  });
 }

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -194,6 +194,7 @@ GridWriteStream.prototype._close = function _close (cb) {
 
   var self = this;
   this._store.close(function (err, file) {
+    self._closing = false;
     if (err) return self._error(err);
     self.emit('close', file);
 

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -82,11 +82,13 @@ util.inherits(GridWriteStream, FlushWritable);
  */
 
 GridWriteStream.prototype._open = function () {
+  if (this._opened) return;
   if (this._opening) return;
   this._opening = true;
 
   var self = this;
   this._store.open(function (err, gs) {
+    self._opening = false;
     if (err) return self._error(err);
     self._opened = true;
     self.emit('open');

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -65,6 +65,7 @@ function GridWriteStream (grid, options) {
 
   this._delayedWrite = null;
   this._delayedFlush = null;
+  this._delayedClose = null;
 
   var self = this;
 
@@ -97,6 +98,13 @@ GridWriteStream.prototype._open = function () {
     if (err) return self._error(err);
     self._opened = true;
     self.emit('open');
+
+    // If _close was called during _store opening, then it was delayed until now, so do the close now
+    if (self._delayedClose) {
+      var closed = self._delayedClose.cb;
+      self._delayedClose = null;
+      return self._closeInternal(closed);
+    }
 
     // If _flush was called during _store opening, then it was delayed until now, so do the flush now (it's necessarily an empty GridFS file, no _write could have been called and have finished)
     if (self._delayedFlush) {
@@ -183,13 +191,14 @@ GridWriteStream.prototype._flush = function (flushed) {
   this._flushInternal(flushed);
 }
 
+
 /**
- * _close
+ * _closeInternal
  *
  * @api private
  */
 
-GridWriteStream.prototype._close = function _close (cb) {
+GridWriteStream.prototype._closeInternal = function (cb) {
   if (!this._opened) return;
   if (this._closing) return;
   this._closing = true;
@@ -203,6 +212,23 @@ GridWriteStream.prototype._close = function _close (cb) {
 
     if (cb) cb();
   });
+}
+
+/**
+ * _close
+ *
+ * @api private
+ */
+
+GridWriteStream.prototype._close = function _close (cb) {
+  if (this._opening) {
+    // if we are still opening the store, then delay the close until it is open.
+    this._delayedClose = { cb: cb };
+    return;
+  }
+
+  // otherwise, do the close now
+  this._closeInternal(cb);
 }
 
 /**

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -159,8 +159,7 @@ GridWriteStream.prototype._write = function (chunk, encoding, done) {
  */
 
 GridWriteStream.prototype._flushInternal = function (flushed) {
-  flushed();
-  this._close();
+  this._close(flushed);
 }
 
 /**
@@ -188,7 +187,7 @@ GridWriteStream.prototype._flush = function (flushed) {
  * @api private
  */
 
-GridWriteStream.prototype._close = function _close () {
+GridWriteStream.prototype._close = function _close (cb) {
   if (!this._opened) return;
   if (this._closing) return;
   this._closing = true;
@@ -197,6 +196,8 @@ GridWriteStream.prototype._close = function _close () {
   this._store.close(function (err, file) {
     if (err) return self._error(err);
     self.emit('close', file);
+
+    if (cb) cb();
   });
 }
 

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -102,10 +102,10 @@ GridWriteStream.prototype._open = function () {
     if (self._delayedFlush) {
       var flushed = self._delayedFlush;
       self._delayedFlush = null;
-      self._flushInternal(flushed);
+      return self._flushInternal(flushed);
     }
 
-    // If _write was called during _store opening, then it was delayed until now, so do the write now
+    // If _write was called during _store opening, then it was delayed until now, so do the write now (_flush could not have been called yet as _write has not finished yet)
     if (self._delayedWrite) {
       var delayedWrite = self._delayedWrite;
       self._delayedWrite = null;

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -33,6 +33,7 @@ function GridWriteStream (grid, options) {
   this._writable = true;
   this._closing = false;
   this._destroyed = false;
+  this._errorEmitted = false;
   this._grid = grid;
 
   // a bit backwards compatible
@@ -211,6 +212,9 @@ GridWriteStream.prototype._close = function _close (cb) {
 
 GridWriteStream.prototype._error = function _error (err) {
   // Stop receiving more data to write, emit `error` and close the store
+  if (this._errorEmitted) return;
+  this._errorEmitted = true;
+
   this._writable = false;
   this.emit('error', err);
   this._close();

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -125,7 +125,7 @@ GridWriteStream.prototype._writeInternal = function (chunk, encoding, done) {
     done();
 
     // If we received an indication to flush - call _needToFlush and close the store.
-    if (self._needToFlush) {
+    if (self._needToFlush && !this._writePending) {
       self._needToFlush();
       self._close();
     }

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -32,6 +32,7 @@ function GridWriteStream (grid, options) {
   this._opening = false;
   this._writable = true;
   this._closing = false;
+  this._destroyed = false;
   this._grid = grid;
 
   // a bit backwards compatible
@@ -225,6 +226,9 @@ GridWriteStream.prototype._error = function _error (err) {
 
 GridWriteStream.prototype.destroy = function destroy (err) {
   // Abort the write stream, even if write not completed
+  if (this._destroyed) return;
+  this._destroyed = true;
+
   if (err === undefined) { err = new Error('destroyed'); }
   this._error(err);
 }

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -197,6 +197,7 @@ GridWriteStream.prototype._close = function _close (cb) {
   var self = this;
   this._store.close(function (err, file) {
     self._closing = false;
+    self._opened = false;
     if (err) return self._error(err);
     self.emit('close', file);
 

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -61,6 +61,7 @@ function GridWriteStream (grid, options) {
   // in the call signature, which is what we want.
   this._store = new grid.mongo.GridStore(grid.db, this.id, this.name, this.mode, this.options);
 
+  this._delayedWrite = null;
   this._delayedFlush = null;
 
   var self = this;
@@ -102,7 +103,7 @@ GridWriteStream.prototype._open = function () {
       self._flushInternal(flushed);
     }
 
-    // If data was sent before store is open start writing to the store
+    // If _write was called during _store opening, then it was delayed until now, so do the write now
     if (self._delayedWrite) {
       var delayedWrite = self._delayedWrite;
       self._delayedWrite = null;
@@ -141,13 +142,13 @@ GridWriteStream.prototype._writeInternal = function (chunk, encoding, done) {
  */
 
 GridWriteStream.prototype._write = function (chunk, encoding, done) {
-  // The store is not open but data is ready to be written so delay the write until the store is opened.
-  if (!this._opened) {
+  if (this._opening) {
+    // if we are still opening the store, then delay the write until it is open.
     this._delayedWrite = {chunk: chunk, encoding: encoding, done: done};
     return;
   }
 
-  // The store is open so pass all arguments to _writeInternal to be written to the gridstore
+  // otherwise, do the write now
   this._writeInternal(chunk, encoding, done);
 }
 

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -157,7 +157,7 @@ GridWriteStream.prototype._write = function (chunk, encoding, done) {
     }
 
     // We are ready to receive a new chunk from the writestream - call done().
-	self._done();
+    self._done();
     });
 
 }

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -92,7 +92,11 @@ GridWriteStream.prototype._open = function () {
     self.emit('open');
 
     // If data was sent before store is open start writing to the store
-    if (self._delayedWrite) return self._writeInternal(self._delayedWrite.chunk, self._delayedWrite.encoding, self._delayedWrite.done);
+    if (self._delayedWrite) {
+      var delayedWrite = self._delayedWrite;
+      self._delayedWrite = null;
+      return self._writeInternal(delayedWrite.chunk, delayedWrite.encoding, delayedWrite.done);
+    }
 
     // If empty file
     if (self._needToFlush  && !this._writePending) {

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -6,7 +6,7 @@
 var util = require('util');
 //var Writable  = require('stream').Writable;
 
-// This is a workaround to implement a _flush method for Writable (like for Transform) to indicate that all data has been flushed to the underlying system. See https://www.npmjs.com/package/flushwritable and https://github.com/joyent/node/issues/7348
+// This is a workaround to implement a _flush method for Writable (like for Transform) to emit the 'finish' event only after all data has been flushed to the underlying system (GridFS). See https://www.npmjs.com/package/flushwritable and https://github.com/joyent/node/issues/7348
 var FlushWritable = require('flushwritable');
 
 /**
@@ -81,7 +81,7 @@ util.inherits(GridWriteStream, FlushWritable);
  * @api private
  */
 
-GridWriteStream.prototype._open = function _open () {
+GridWriteStream.prototype._open = function () {
   if (this._opening) return;
   this._opening = true;
 
@@ -146,7 +146,7 @@ GridWriteStream.prototype._write = function (chunk, encoding, done) {
   // The store is not open but data is ready to be written so delay the write until the store is opened.
   if (!this._opened) {
     this._delayedWrite = {chunk: chunk, encoding: encoding, done: done};
-    return
+    return;
   }
 
   // The store is open so pass all arguments to _writeInternal to be written to the gridstore
@@ -160,7 +160,7 @@ GridWriteStream.prototype._write = function (chunk, encoding, done) {
  */
 
 GridWriteStream.prototype._flush = function (flushed) {
-  // If all data has been flushed to the gridstore call flushed and close the store.
+  // If no write is pending then complete the flush
   if (!this._writePending && this._opened) {
     flushed();
     return this._close();

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "flushwritable": "*"
+    "flushwritable": "^1.0.0"
   },
   "devDependencies": {
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "flushwritable": "*",
+    "flushwritable": "*"
   },
   "devDependencies": {
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "make test"
   },
   "dependencies": {
+    "flushwritable": "*",
   },
   "devDependencies": {
     "mocha": "*",

--- a/test/index.js
+++ b/test/index.js
@@ -341,6 +341,24 @@ describe('test', function(){
 
       var pipe = readStream.pipe(ws);
     });
+
+    it('should emit an error on destroy()', function(done){
+      var readStream = fs.createReadStream(imgReadPath, { bufferSize: 1024 });
+      var ws = g.createWriteStream({ filename: 'logo.png'});
+
+      var error = new Error('test error from destroy');
+
+      ws.on('error', function (err) {
+        assert(err === error);
+        done();
+      });
+
+      ws.on('progress', function (progress) {
+        ws.destroy(error);
+      });
+
+      var pipe = readStream.pipe(ws);
+    });
   });
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -363,6 +363,17 @@ describe('test', function(){
 
       var pipe = readStream.pipe(ws);
     });
+
+    it('should emit error on destroy() on nextTick', function(done){
+      var ws = g.createWriteStream({ filename: 'logo.png'});
+
+      ws.destroy(new Error('early destroy'));
+
+      ws.on('error', function (err) {
+        done();
+      });
+    });
+
   });
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -374,6 +374,27 @@ describe('test', function(){
       });
     });
 
+    it('should emit close if open is emitted on destroy()', function(done){
+      var ws = g.createWriteStream({ filename: 'logo.png'});
+
+      var opened = false;
+      var error = false;
+      ws.on('open', function () {
+        opened = true;
+      });
+      ws.on('close', function () {
+        assert(opened);
+        assert(error);
+        done();
+      });
+
+      ws.destroy();
+
+      ws.on('error', function (err) {
+        error = true;
+      });
+    });
+
   });
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -342,19 +342,23 @@ describe('test', function(){
       var pipe = readStream.pipe(ws);
     });
 
-    it('should emit an error on destroy()', function(done){
+    it('should emit one error on destroy()', function(done){
       var readStream = fs.createReadStream(imgReadPath, { bufferSize: 1024 });
       var ws = g.createWriteStream({ filename: 'logo.png'});
 
       var error = new Error('test error from destroy');
+      var errorCounter = 0;
 
       ws.on('error', function (err) {
+        errorCounter += 1;
+        assert(errorCounter === 1);
         assert(err === error);
         done();
       });
 
       ws.on('progress', function (progress) {
         ws.destroy(error);
+        ws.destroy(); // test multiple destroy call
       });
 
       var pipe = readStream.pipe(ws);

--- a/test/index.js
+++ b/test/index.js
@@ -146,11 +146,6 @@ describe('test', function(){
           assert('function' == typeof ws.destroy)
         })
       })
-      describe('destroySoon', function(){
-        it('should be a function', function(){
-          assert('function' == typeof ws.destroySoon)
-        })
-      })
     });
     it('should provide piping from a readableStream into GridFS', function(done){
       var readStream = fs.createReadStream(imgReadPath, { bufferSize: 1024 });


### PR DESCRIPTION
Here is a review with fixes and cleanups on top of riaan53/gridfs-stream master, for Writable stream only.

* no more internal buffering, see aheckmann/gridfs-stream/issues/58
* `finish` event is emitted when the file is fully on GridFS (using flushwritable).
* `destroy()` emits an error (and the error can be specified as destroy(err), because the write to GridFS may be aborted, so the file is corrupted.
* Added documentation and tests for special events `open` and `close` (and `finish`)
* Added documentation and tests for `destroy`

Pending questions:

I don't know what we should do in case of error:
* Internally: Currently we just call _error() which emits error and then _close().
 It works, but we could do other things: _write and _flush give callbacks that accept an error as first argument. If there is either a _write or a _flush (we cannot have both at the same time) running during the error (for example _store.open() failed, or _store.write() failed, or _store.close() failed), then we could (also?) call that callback with the error.
 From what I read in the code of nodejs v0.10.31 and v0.12.0, both with indirectly emit error, and the _write() callback will call the optional write() callback so the caller will be notified too. It may be useful to notify the caller this way, but it's harder to do it properly: we need to avoid multiple error emitted, and we still need to call _close() (and maybe in a precise order: it may be useful to guarantee that 'error' happens before (or after?) 'close'; for that we could delay _close() to nextTick). I don't know what is the best practice here... Maybe we should ask on nodejs mailing list?
* externally: We always call _store.close(), so we always commit the file to GridFS by writing the document in the files collection. This may not be the best solution in case of error: If an error happened, the file may be corrupted, but we store it like no error happened. Two solutions:
 * keep commiting the file to GridFS, but add an extra metadata field error to notify that this file may be corrupted. It would be up to the caller to remove the file afterward if it wants that, or not.
 * remove the file and the chunks on error, because the file is likely corrupted, but it's an issue if the file was overwriting another file, because we would want to rollback to a previous state (which is what we would expect. It's how AWS S3 works for example), and the current GridStore from nodejs mongodb driver 2.0.15 deletes the old chunks before starting to write the new ones, so we cannot... Maybe it's a bug of the mongodb driver, but I don't see how it could implement what we want without performance issues.

I haven't reviewed the Readable stream yet, I'm less familiar with Readable streams than with Writable ones...


PS: I patched the commit https://github.com/riaan53/gridfs-stream/commit/c6ac486daf906758d92853b3b569020df646e3bf in this branch to remove the wrongly committed temporary file `test/tmp/1mbBlob`.