### PR TITLE
Fix a bug of GridWriteStream constructor

### DIFF
--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -41,11 +41,11 @@ function GridWriteStream (grid, options) {
 		options = { filename: options };
 	}
 	this.options = options || {};
-	if(options._id) {
-		this.id = grid.tryParseObjectId(options._id);
+	if(this.options._id) {
+		this.id = grid.tryParseObjectId(this.options._id);
 
 		if(!this.id) {
-			this.id = options._id;
+			this.id = this.options._id;
 		}
 	}
 

--- a/test/index.js
+++ b/test/index.js
@@ -393,6 +393,19 @@ describe('test', function(){
       });
     });
 
+    it('should create GridWriteStream without options.', function(done){
+      var ws = g.createWriteStream();
+      
+      ws.on('close', function () {
+        done();
+      });
+      
+      ws.destroy();
+      
+      ws.on('error', function (err) {
+        assert(!err);
+      });
+    });
   });
 
 


### PR DESCRIPTION
Hello.
I use this library in my project, and I found a bug in GridWriteStream constructor.

In README.md, written as following:

```js
var writestream = gfs.createWriteStream([options]);
fs.createReadStream('/some/path').pipe(writestream);
```

So I wrote this code and ran it.

```js
var writestream = gfs.createWriteStream();
```

It failed, and it output some error logs.

```js
TypeError: Cannot read property '_id' of undefined
      at new GridWriteStream (C:\Users\pine\Dropbox\Repos\_fork\gridfs-stream\lib\writestream.js:44:12)
      at Grid.createWriteStream (C:\Users\pine\Dropbox\Repos\_fork\gridfs-stream\lib\index.js:42:10)
```

I fixed this bug, and added some tests.
Thank you.