### PR TITLE
Update Readme.md (connection must be opened)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,7 @@ var Grid = require('gridfs-stream');
 
 // create or use an existing mongodb-native db instance
 var db = new mongo.Db('yourDatabaseName', new mongo.Server("127.0.0.1", 27017));
+// make sure the db instance is open before passing into `Grid`
 var gfs = Grid(db, mongo);
 
 // streaming to gridfs


### PR DESCRIPTION
The first example doesn't mention that the connection must be opened before passing it to Grid.