### PR TITLE
Replace Cursor.nextObject because it was removed from node-mongodb-native library

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -140,7 +140,7 @@ Grid.prototype.findOne = function (options, callback) {
   collection.find(find, function(err, cursor) {
     if (err) { return callback(err); }
     if (!cursor) { return callback(new Error('Collection not found')); }
-    cursor.nextObject(callback);
+    cursor.next(callback);
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "mocha": "*",
-    "mongodb": "2.0.15",
+    "mongodb": "3.1.1",
     "checksum": "~0.1.1"
   },
   "optionalDependencies": {},


### PR DESCRIPTION
https://github.com/HolgerFrank/gridfs-stream/commit/9cd82a002bd63c07b5e5b70bf2ef2922527a6a28